### PR TITLE
feat: type .expand on SDK read results (#37)

### DIFF
--- a/.changeset/typed-expand-results.md
+++ b/.changeset/typed-expand-results.md
@@ -1,0 +1,29 @@
+---
+"@karnak19/pbkit": minor
+---
+
+Type `.expand` on SDK read results
+
+Read functions (`getX`, `getFirstX`, `listX`, `getFullListX`) for collections with
+relations are now generic over the requested `expand` string, and the result
+carries a typed `.expand` matching what you asked for:
+
+```ts
+const article = await getArticle("RECORD_ID", { expand: "author,categories" })
+article.expand?.author     // UsersRecord
+article.expand?.categories // CategoriesRecord[]  (multi-relation → array)
+
+const comment = await getComment("RECORD_ID", { expand: "article.author" })
+comment.expand?.article.expand?.author // UsersRecord  (nested)
+```
+
+`expand` stays the native PocketBase comma-separated string, and `.expand` is
+optional (PocketBase omits empty/unauthorized relations). This closes the main
+gap with `pocketbase-typegen`, which typed `record.expand.x` but left expand
+input untyped.
+
+The generator now emits an `XxxRelations` map per collection plus shared
+`BuildExpand`/`Split` helper types. The existing `XxxExpand` union is still
+generated. Note: because the result is inferred from the literal you pass, the
+`expand` **input** is now a plain `string` (no autocomplete). Reverse (`_via_`)
+back-relations are not yet covered.

--- a/apps/docs/src/content/docs/explanation/relations-and-expand.md
+++ b/apps/docs/src/content/docs/explanation/relations-and-expand.md
@@ -34,8 +34,9 @@ pbkit enumerates these walks up to a maximum length and emits them as a union:
 export type CommentsExpand = "article" | "article.author" | "article.categories" | "author"
 ```
 
-This is why expand autocomplete only ever offers paths that actually exist in
-your schema — they are computed from the graph, not guessed.
+The same graph drives the `XxxRelations` map, which lets the SDK resolve the
+`expand` string you pass into a typed `.expand` result — the paths are computed
+from the graph, not guessed.
 
 ## Why depth is bounded
 

--- a/apps/docs/src/content/docs/how-to/migrate-from-pocketbase-typegen.md
+++ b/apps/docs/src/content/docs/how-to/migrate-from-pocketbase-typegen.md
@@ -22,7 +22,7 @@ sites.
 | Output | one `pocketbase-types.ts` | `types.gen.ts`, `client.gen.ts`, `sdk.gen.ts` |
 | Configuration | CLI flags | a `pbkit.config.ts` file |
 | Data access | cast `pb` to `TypedPocketBase`, call `pb.collection(...)` | import generated functions |
-| Expanding relations | manual generic parameters | typed `expand` option |
+| Expanding relations | manual generic parameters | inferred from the `expand` string — typed `record.expand.x` |
 
 ## Step 1: Swap the dependencies
 
@@ -209,15 +209,19 @@ const article = await pb
 article.expand?.author.email
 ```
 
-pbkit types the `expand` option directly from the schema, so you get
-autocomplete and no manual generics:
+pbkit infers the expanded shape from the `expand` string you pass — no manual
+generics. `record.expand.x` is fully typed, just like pocketbase-typegen, while
+the expand paths are computed from the schema:
 
 ```ts
 // after
 const article = await getArticle("RECORD_ID", { expand: "author" })
+
+article.expand?.author // typed as UsersRecord — read it directly
 ```
 
-See [Expand types](/reference/expand-types) for how expand paths are typed.
+Multi-relations come back as arrays and nested paths nest the `expand` object.
+See [Expand types](/reference/expand-types) for the full details.
 
 ## Authentication
 

--- a/apps/docs/src/content/docs/reference/expand-types.md
+++ b/apps/docs/src/content/docs/reference/expand-types.md
@@ -6,8 +6,8 @@ sidebar:
 ---
 
 For each collection that has relation fields, pbkit generates an `XxxExpand`
-type: a union of every valid `expand` path. This gives you autocomplete and
-compile-time checking for the `expand` option in SDK calls.
+type: a union of every valid `expand` path, and an `XxxRelations` map that drives
+the typed `.expand` shape on read results.
 
 For the concept behind how these paths are computed, see
 [Relations and expand paths](/explanation/relations-and-expand).
@@ -29,6 +29,25 @@ export type CommentsExpand = "article" | "article.author" | "article.categories"
 An `XxxExpand` type is only generated when the collection has at least one
 relation field.
 
+## Relations map
+
+Alongside `XxxExpand`, pbkit emits an `XxxRelations` map describing each forward
+relation's target record type and cardinality. The SDK uses this (with a small
+set of shared helper types — `BuildExpand`, `Split`) to compute the typed
+`.expand` result from the requested expand string:
+
+```ts
+export type ArticlesRelations = {
+  author: { rec: UsersRecord; coll: "users"; multi: false }
+  categories: { rec: CategoriesRecord; coll: "categories"; multi: true }
+}
+```
+
+`multi: true` (the relation's `maxSelect > 1`) means the expanded value is an
+array. You normally don't reference these directly — they exist so
+`getArticle(id, { expand: "author" }).expand?.author` is typed as `UsersRecord`.
+See [Generated SDK → Typed expand](/reference/generated-sdk#typed-expand).
+
 ## Depth
 
 The maximum path depth is controlled by `types.expandDepth` (default: `2`):
@@ -47,15 +66,19 @@ With `expandDepth: 1`, `CommentsExpand` would be only `"article" | "author"`.
 
 ## Usage
 
-The `expand` option on SDK functions is typed to the collection's `XxxExpand`
-type, so valid paths autocomplete:
+Pass the native PocketBase comma-separated `expand` string to any read function.
+The result is typed from that literal, so `.expand` is populated accordingly:
 
 ```ts
 import { getArticle } from "./generated/sdk.gen"
 
-const article = await getArticle("RECORD_ID", {
-  expand: "author",
-})
+const article = await getArticle("RECORD_ID", { expand: "author" })
+article.expand?.author // UsersRecord
 ```
 
-See [Generated SDK](/reference/generated-sdk#typed-expand) for the full signatures.
+The `expand` input itself is a plain `string` (no autocomplete) — typing the
+result is the tradeoff. The `XxxExpand` union remains available if you want to
+constrain or document valid paths yourself.
+
+See [Generated SDK → Typed expand](/reference/generated-sdk#typed-expand) for the
+full signatures.

--- a/apps/docs/src/content/docs/reference/generated-sdk.md
+++ b/apps/docs/src/content/docs/reference/generated-sdk.md
@@ -43,16 +43,39 @@ for a specific call.
 
 ## Typed expand
 
-When a collection has relations, the `expand` option is typed to the collection's `Expand` type:
+When a collection has relation fields, the read functions (`getX`, `getFirstX`,
+`listX`, `getFullListX`) are **generic over the requested expand string**, and the
+result carries a typed `.expand` matching exactly what you asked for:
 
 ```ts
 import { getArticle } from "./generated/sdk.gen"
 
-// expand is typed to ArticlesExpand — you get autocomplete
-const article = await getArticle("RECORD_ID", {
-  expand: "author",
-})
+const article = await getArticle("RECORD_ID", { expand: "author" })
+article.expand?.author // typed as UsersRecord
+
+const withCats = await getArticle("RECORD_ID", { expand: "author,categories" })
+withCats.expand?.author      // UsersRecord
+withCats.expand?.categories  // CategoriesRecord[]  (multi-relation → array)
+
+// Nested paths nest the expand object
+const nested = await getComment("RECORD_ID", { expand: "article.author" })
+nested.expand?.article.expand?.author // UsersRecord
+
+// No expand requested → no `.expand` on the result
+const plain = await getArticle("RECORD_ID")
 ```
+
+`expand` is the native PocketBase comma-separated string. `.expand` is optional
+on the result because PocketBase omits relations that are empty or unauthorized.
+
+:::note
+Because the result type is inferred from the literal you pass, the `expand`
+**input** is a plain `string` (no autocomplete). The valid paths are still
+generated as the [`XxxExpand`](/reference/expand-types) union if you want to
+reference or validate them yourself. Typing the result this way is what lets you
+read `record.expand.x` safely — see
+[issue #37](https://github.com/Karnak19/pbkit/issues/37).
+:::
 
 ## Custom fetch
 

--- a/packages/pbkit/src/sdk-generator/generate.ts
+++ b/packages/pbkit/src/sdk-generator/generate.ts
@@ -16,14 +16,26 @@ function singularize(name: string): string {
   return name;
 }
 
-function hasExpandType(col: CollectionSchema, ir: SchemaIR): boolean {
-  return ir.relations.some((r) => r.collectionName === col.name);
+// A collection has a typed relations map (and thus a typed `.expand` result)
+// when it has at least one forward relation whose target is generated. The
+// exclusion filter must match the type generator's `relationsMapType`, or the
+// SDK would reference an `XxxRelations`/`BuildExpand`/`Split` that types.gen.ts
+// never emitted.
+function hasRelationsMap(
+  col: CollectionSchema,
+  ir: SchemaIR,
+  collections?: CollectionsConfig,
+): boolean {
+  return ir.relations.some(
+    (r) => r.collectionName === col.name && !isCollectionExcluded(r.targetCollectionName, collections),
+  );
 }
 
-function expandParam(col: CollectionSchema, ir: SchemaIR): string {
-  if (!hasExpandType(col, ir)) return "RequestOptions";
+// The `.expand` shape contributed to a read result, given the captured
+// expand-string generic `S`. Resolves to `{}` when no expand was requested.
+function expandResult(col: CollectionSchema): string {
   const p = pascalCase(col.name);
-  return `Omit<RequestOptions, "expand"> & { expand?: ${p}Expand }`;
+  return `(S extends string ? { expand?: BuildExpand<${p}Relations, Split<S>> } : {})`;
 }
 
 export function generateClientFile(options: SdkGenerateOptions = {}): string {
@@ -48,47 +60,57 @@ function crudFunctions(
   const p = pascalCase(col.name);
   const s = pascalCase(singularize(col.name));
   const c = JSON.stringify(col.name);
-  const ep = expandParam(col, ir);
   const lines: string[] = [];
   const op = (name: string) => isOperationEnabled(col.name, name as any, collections);
 
+  // Collections with forward relations get read functions generic over the
+  // requested expand string, so the result carries a typed `.expand`.
+  const rel = hasRelationsMap(col, ir, collections);
+  const gen = rel ? "<const S extends string | undefined = undefined>" : "";
+  const reqOpt = rel ? `Omit<RequestOptions, "expand"> & { expand?: S }` : "RequestOptions";
+  const listOpt = rel ? `Omit<ListParams, "expand"> & { expand?: S }` : "ListParams";
+  const rec = rel ? `${p}Record & ${expandResult(col)}` : `${p}Record`;
+  // Parenthesize so the array applies to the whole intersection, not just the
+  // trailing conditional (`A & B[]` would parse as `A & (B[])`).
+  const recArr = rel ? `(${rec})[]` : `${rec}[]`;
+
   if (op("get")) {
     lines.push(
-      `export async function get${s}(id: string, options?: ${ep}, opts?: { client?: PbClient }): Promise<${p}Record> {`,
+      `export async function get${s}${gen}(id: string, options?: ${reqOpt}, opts?: { client?: PbClient }): Promise<${rec}> {`,
     );
     lines.push("  const pb = opts?.client ?? client");
-    lines.push(`  return pb.collection(${c}).getOne(id, options) as Promise<${p}Record>`);
+    lines.push(`  return pb.collection(${c}).getOne(id, options) as Promise<${rec}>`);
     lines.push("}");
     lines.push("");
   }
   if (op("getFirst")) {
     lines.push(
-      `export async function getFirst${s}(filter: string, options?: ${ep}, opts?: { client?: PbClient }): Promise<${p}Record> {`,
+      `export async function getFirst${s}${gen}(filter: string, options?: ${reqOpt}, opts?: { client?: PbClient }): Promise<${rec}> {`,
     );
     lines.push("  const pb = opts?.client ?? client");
     lines.push(
-      `  return pb.collection(${c}).getFirstListItem(filter, options) as Promise<${p}Record>`,
+      `  return pb.collection(${c}).getFirstListItem(filter, options) as Promise<${rec}>`,
     );
     lines.push("}");
     lines.push("");
   }
   if (op("list")) {
     lines.push(
-      `export async function list${p}(params?: ListParams, opts?: { client?: PbClient }): Promise<ListResult<${p}Record>> {`,
+      `export async function list${p}${gen}(params?: ${listOpt}, opts?: { client?: PbClient }): Promise<ListResult<${rec}>> {`,
     );
     lines.push("  const pb = opts?.client ?? client");
     lines.push(
-      `  return pb.collection(${c}).getList(params?.page, params?.perPage, params) as Promise<ListResult<${p}Record>>`,
+      `  return pb.collection(${c}).getList(params?.page, params?.perPage, params) as Promise<ListResult<${rec}>>`,
     );
     lines.push("}");
     lines.push("");
   }
   if (op("getFullList")) {
     lines.push(
-      `export async function getFullList${p}(params?: ListParams, opts?: { client?: PbClient }): Promise<${p}Record[]> {`,
+      `export async function getFullList${p}${gen}(params?: ${listOpt}, opts?: { client?: PbClient }): Promise<${recArr}> {`,
     );
     lines.push("  const pb = opts?.client ?? client");
-    lines.push(`  return pb.collection(${c}).getFullList(params) as Promise<${p}Record[]>`);
+    lines.push(`  return pb.collection(${c}).getFullList(params) as Promise<${recArr}>`);
     lines.push("}");
     lines.push("");
   }
@@ -229,9 +251,12 @@ export function generateSdk(
   const typeImports = cols.flatMap((c) => {
     const p = pascalCase(c.name);
     const imports = [`${p}Record`, `${p}Create`, `${p}Update`];
-    if (hasExpandType(c, ir)) imports.push(`${p}Expand`);
+    if (hasRelationsMap(c, ir, options.collections)) imports.push(`${p}Relations`);
     return imports;
   });
+  if (cols.some((c) => hasRelationsMap(c, ir, options.collections))) {
+    typeImports.push("BuildExpand", "Split");
+  }
 
   const parts: string[] = [];
 

--- a/packages/pbkit/src/test/__snapshots__/sdk-generator.test.ts.snap
+++ b/packages/pbkit/src/test/__snapshots__/sdk-generator.test.ts.snap
@@ -5,7 +5,7 @@ exports[`generateSdk snapshot 1`] = `
 
 import { client } from "./client.gen"
 import type { PbClient } from "./client.gen"
-import type { UsersRecord, UsersCreate, UsersUpdate, CategoriesRecord, CategoriesCreate, CategoriesUpdate, ArticlesRecord, ArticlesCreate, ArticlesUpdate, ArticlesExpand, CommentsRecord, CommentsCreate, CommentsUpdate, CommentsExpand } from "./types.gen"
+import type { UsersRecord, UsersCreate, UsersUpdate, CategoriesRecord, CategoriesCreate, CategoriesUpdate, ArticlesRecord, ArticlesCreate, ArticlesUpdate, ArticlesRelations, CommentsRecord, CommentsCreate, CommentsUpdate, CommentsRelations, BuildExpand, Split } from "./types.gen"
 
 export type { PbClient }
 
@@ -173,24 +173,24 @@ export async function deleteCategory(id: string, opts?: { client?: PbClient; fet
 
 // --- Articles ---
 
-export async function getArticle(id: string, options?: Omit<RequestOptions, "expand"> & { expand?: ArticlesExpand }, opts?: { client?: PbClient }): Promise<ArticlesRecord> {
+export async function getArticle<const S extends string | undefined = undefined>(id: string, options?: Omit<RequestOptions, "expand"> & { expand?: S }, opts?: { client?: PbClient }): Promise<ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {})> {
   const pb = opts?.client ?? client
-  return pb.collection("articles").getOne(id, options) as Promise<ArticlesRecord>
+  return pb.collection("articles").getOne(id, options) as Promise<ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {})>
 }
 
-export async function getFirstArticle(filter: string, options?: Omit<RequestOptions, "expand"> & { expand?: ArticlesExpand }, opts?: { client?: PbClient }): Promise<ArticlesRecord> {
+export async function getFirstArticle<const S extends string | undefined = undefined>(filter: string, options?: Omit<RequestOptions, "expand"> & { expand?: S }, opts?: { client?: PbClient }): Promise<ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {})> {
   const pb = opts?.client ?? client
-  return pb.collection("articles").getFirstListItem(filter, options) as Promise<ArticlesRecord>
+  return pb.collection("articles").getFirstListItem(filter, options) as Promise<ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {})>
 }
 
-export async function listArticles(params?: ListParams, opts?: { client?: PbClient }): Promise<ListResult<ArticlesRecord>> {
+export async function listArticles<const S extends string | undefined = undefined>(params?: Omit<ListParams, "expand"> & { expand?: S }, opts?: { client?: PbClient }): Promise<ListResult<ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {})>> {
   const pb = opts?.client ?? client
-  return pb.collection("articles").getList(params?.page, params?.perPage, params) as Promise<ListResult<ArticlesRecord>>
+  return pb.collection("articles").getList(params?.page, params?.perPage, params) as Promise<ListResult<ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {})>>
 }
 
-export async function getFullListArticles(params?: ListParams, opts?: { client?: PbClient }): Promise<ArticlesRecord[]> {
+export async function getFullListArticles<const S extends string | undefined = undefined>(params?: Omit<ListParams, "expand"> & { expand?: S }, opts?: { client?: PbClient }): Promise<(ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {}))[]> {
   const pb = opts?.client ?? client
-  return pb.collection("articles").getFullList(params) as Promise<ArticlesRecord[]>
+  return pb.collection("articles").getFullList(params) as Promise<(ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {}))[]>
 }
 
 export async function createArticle(data: ArticlesCreate, opts?: { client?: PbClient; fetch?: typeof fetch }): Promise<ArticlesRecord> {
@@ -211,24 +211,24 @@ export async function deleteArticle(id: string, opts?: { client?: PbClient; fetc
 
 // --- Comments ---
 
-export async function getComment(id: string, options?: Omit<RequestOptions, "expand"> & { expand?: CommentsExpand }, opts?: { client?: PbClient }): Promise<CommentsRecord> {
+export async function getComment<const S extends string | undefined = undefined>(id: string, options?: Omit<RequestOptions, "expand"> & { expand?: S }, opts?: { client?: PbClient }): Promise<CommentsRecord & (S extends string ? { expand?: BuildExpand<CommentsRelations, Split<S>> } : {})> {
   const pb = opts?.client ?? client
-  return pb.collection("comments").getOne(id, options) as Promise<CommentsRecord>
+  return pb.collection("comments").getOne(id, options) as Promise<CommentsRecord & (S extends string ? { expand?: BuildExpand<CommentsRelations, Split<S>> } : {})>
 }
 
-export async function getFirstComment(filter: string, options?: Omit<RequestOptions, "expand"> & { expand?: CommentsExpand }, opts?: { client?: PbClient }): Promise<CommentsRecord> {
+export async function getFirstComment<const S extends string | undefined = undefined>(filter: string, options?: Omit<RequestOptions, "expand"> & { expand?: S }, opts?: { client?: PbClient }): Promise<CommentsRecord & (S extends string ? { expand?: BuildExpand<CommentsRelations, Split<S>> } : {})> {
   const pb = opts?.client ?? client
-  return pb.collection("comments").getFirstListItem(filter, options) as Promise<CommentsRecord>
+  return pb.collection("comments").getFirstListItem(filter, options) as Promise<CommentsRecord & (S extends string ? { expand?: BuildExpand<CommentsRelations, Split<S>> } : {})>
 }
 
-export async function listComments(params?: ListParams, opts?: { client?: PbClient }): Promise<ListResult<CommentsRecord>> {
+export async function listComments<const S extends string | undefined = undefined>(params?: Omit<ListParams, "expand"> & { expand?: S }, opts?: { client?: PbClient }): Promise<ListResult<CommentsRecord & (S extends string ? { expand?: BuildExpand<CommentsRelations, Split<S>> } : {})>> {
   const pb = opts?.client ?? client
-  return pb.collection("comments").getList(params?.page, params?.perPage, params) as Promise<ListResult<CommentsRecord>>
+  return pb.collection("comments").getList(params?.page, params?.perPage, params) as Promise<ListResult<CommentsRecord & (S extends string ? { expand?: BuildExpand<CommentsRelations, Split<S>> } : {})>>
 }
 
-export async function getFullListComments(params?: ListParams, opts?: { client?: PbClient }): Promise<CommentsRecord[]> {
+export async function getFullListComments<const S extends string | undefined = undefined>(params?: Omit<ListParams, "expand"> & { expand?: S }, opts?: { client?: PbClient }): Promise<(CommentsRecord & (S extends string ? { expand?: BuildExpand<CommentsRelations, Split<S>> } : {}))[]> {
   const pb = opts?.client ?? client
-  return pb.collection("comments").getFullList(params) as Promise<CommentsRecord[]>
+  return pb.collection("comments").getFullList(params) as Promise<(CommentsRecord & (S extends string ? { expand?: BuildExpand<CommentsRelations, Split<S>> } : {}))[]>
 }
 
 export async function createComment(data: CommentsCreate, opts?: { client?: PbClient; fetch?: typeof fetch }): Promise<CommentsRecord> {

--- a/packages/pbkit/src/test/__snapshots__/type-generator.test.ts.snap
+++ b/packages/pbkit/src/test/__snapshots__/type-generator.test.ts.snap
@@ -85,6 +85,11 @@ export type ArticlesUpdate = Partial<ArticlesCreate>
 
 export type ArticlesExpand = "author" | "categories"
 
+export type ArticlesRelations = {
+  author: { rec: UsersRecord; coll: "users"; multi: false }
+  categories: { rec: CategoriesRecord; coll: "categories"; multi: true }
+}
+
 // Comments
 
 export type CommentsRecord = BaseRecord & {
@@ -102,6 +107,35 @@ export type CommentsCreate = {
 export type CommentsUpdate = Partial<CommentsCreate>
 
 export type CommentsExpand = "article" | "article.author" | "article.categories" | "author"
+
+export type CommentsRelations = {
+  article: { rec: ArticlesRecord; coll: "articles"; multi: false }
+  author: { rec: UsersRecord; coll: "users"; multi: false }
+}
+
+type RelationsMap = {
+  "users": {}
+  "categories": {}
+  "articles": ArticlesRelations
+  "comments": CommentsRelations
+}
+
+type Trim<S extends string> = S extends \` \${infer R}\` ? Trim<R> : S extends \`\${infer R} \` ? Trim<R> : S
+type Split<S extends string> = S extends \`\${infer H},\${infer T}\` ? Trim<H> | Split<T> : Trim<S>
+type Head<P extends string> = P extends \`\${infer H}.\${string}\` ? H : P
+type Under<P extends string, K extends string> = P extends \`\${K}.\${infer R}\` ? R : never
+type RelEntry = { rec: unknown; coll: keyof RelationsMap; multi: boolean }
+type ExpandValue<E extends RelEntry, Rest extends string> = [Rest] extends [never]
+  ? E["rec"]
+  : E["rec"] & { expand?: BuildExpand<RelationsMap[E["coll"]], Rest> }
+export type BuildExpand<R, P extends string> = {
+  [K in Head<P> & keyof R]: R[K] extends RelEntry
+    ? R[K]["multi"] extends true
+      ? ExpandValue<R[K], Under<P, K>>[]
+      : ExpandValue<R[K], Under<P, K>>
+    : never
+}
+export type { Split }
 
 export type CollectionName = "users" | "categories" | "articles" | "comments"
 "

--- a/packages/pbkit/src/test/config-and-generate.test.ts
+++ b/packages/pbkit/src/test/config-and-generate.test.ts
@@ -82,7 +82,7 @@ describe("generateProject", () => {
     expect(types).toContain("ArticlesRecord")
 
     const sdk = readFileSync(resolve(outDir, "sdk.gen.ts"), "utf-8")
-    expect(sdk).toContain("getArticle(")
+    expect(sdk).toContain("getArticle<")
     expect(sdk).toContain("createArticle(")
   })
 

--- a/packages/pbkit/src/test/expand-typecheck.test.ts
+++ b/packages/pbkit/src/test/expand-typecheck.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from "bun:test"
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { parseJson } from "../schema-parser"
+import { generate } from "../type-generator"
+import fullSchema from "./fixtures/full-schema.json"
+
+// Compile-time acceptance test for issue #37: the generated expand machinery
+// must resolve a PocketBase comma-separated expand string into the correct
+// nested `.expand` result shape. We generate types.gen.ts, drop a consumer
+// next to it with type-level assertions (plus a negative `@ts-expect-error`
+// case), and run `tsc --noEmit` over both — so the assertions can never drift
+// from the generator.
+describe("expand result typing (tsc)", () => {
+  test("BuildExpand resolves single, multi, multi-path and nested expands", () => {
+    const ir = parseJson(fullSchema)
+    const typesSrc = generate(ir)
+
+    const consumer = `
+import type {
+  BuildExpand, Split, ArticlesRelations, CommentsRelations,
+  UsersRecord, CategoriesRecord, ArticlesRecord,
+} from "./types.gen"
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false
+type Expect<T extends true> = T
+
+// single relation -> TargetRecord
+type Single = BuildExpand<ArticlesRelations, Split<"author">>
+type _single = Expect<Equal<Single, { author: UsersRecord }>>
+
+// multi relation (maxSelect > 1) -> TargetRecord[]
+type Multi = BuildExpand<ArticlesRelations, Split<"categories">>
+type _multi = Expect<Equal<Multi, { categories: CategoriesRecord[] }>>
+
+// multiple comma-separated paths fall out as multiple keys
+type MultiPath = BuildExpand<ArticlesRelations, Split<"author, categories">>
+type _multiPath = Expect<Equal<MultiPath, { author: UsersRecord; categories: CategoriesRecord[] }>>
+
+// nested path -> nested optional expand on the parent record
+type Nested = BuildExpand<CommentsRelations, Split<"article.author">>
+type _nested = Expect<Equal<Nested, { article: ArticlesRecord & { expand?: { author: UsersRecord } } }>>
+
+// negative: the value must match the resolved record type
+// @ts-expect-error author resolves to UsersRecord, not CategoriesRecord
+const bad: Single = { author: {} as CategoriesRecord }
+void bad
+`
+
+    const dir = mkdtempSync(join(tmpdir(), "pbkit-expand-"))
+    try {
+      writeFileSync(join(dir, "types.gen.ts"), typesSrc)
+      writeFileSync(join(dir, "consumer.ts"), consumer)
+
+      const tsc = join(import.meta.dir, "../../../../node_modules/.bin/tsc")
+      const proc = Bun.spawnSync(
+        [
+          tsc,
+          "--noEmit",
+          "--strict",
+          "--target",
+          "ES2022",
+          "--moduleResolution",
+          "bundler",
+          "--module",
+          "ESNext",
+          join(dir, "types.gen.ts"),
+          join(dir, "consumer.ts"),
+        ],
+        { cwd: dir },
+      )
+
+      const out = proc.stdout.toString() + proc.stderr.toString()
+      expect(out).toBe("")
+      expect(proc.exitCode).toBe(0)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }, 30_000)
+})

--- a/packages/pbkit/src/test/sdk-generator.test.ts
+++ b/packages/pbkit/src/test/sdk-generator.test.ts
@@ -56,10 +56,10 @@ describe("generateSdk", () => {
   });
 
   test("generates CRUD for base collections", () => {
-    expect(output).toContain("export async function getArticle(");
-    expect(output).toContain("export async function getFirstArticle(");
-    expect(output).toContain("export async function listArticles(");
-    expect(output).toContain("export async function getFullListArticles(");
+    expect(output).toContain("export async function getArticle<");
+    expect(output).toContain("export async function getFirstArticle<");
+    expect(output).toContain("export async function listArticles<");
+    expect(output).toContain("export async function getFullListArticles<");
     expect(output).toContain("export async function createArticle(");
     expect(output).toContain("export async function updateArticle(");
     expect(output).toContain("export async function deleteArticle(");
@@ -95,12 +95,12 @@ describe("generateSdk", () => {
   });
 
   test("singularizes collection names correctly", () => {
-    expect(output).toContain("getArticle(");
-    expect(output).toContain("listArticles(");
+    expect(output).toContain("getArticle<");
+    expect(output).toContain("listArticles<");
     expect(output).toContain("getCategory(");
     expect(output).toContain("listCategories(");
-    expect(output).toContain("getComment(");
-    expect(output).toContain("listComments(");
+    expect(output).toContain("getComment<");
+    expect(output).toContain("listComments<");
     expect(output).toContain("getUser(");
   });
 
@@ -150,27 +150,73 @@ describe("generateSdk", () => {
     expect(excluded).not.toContain("CommentsRecord");
   });
 
+  test("does not emit a typed expand when all of a collection's relation targets are excluded", () => {
+    // comments relates only to articles + users; excluding both leaves it with
+    // no generated relation target, so the type generator emits no
+    // CommentsRelations. The SDK must not reference it (regression: it used to
+    // import a non-existent CommentsRelations/BuildExpand/Split).
+    const out = generateSdk(ir, {
+      collections: { articles: { exclude: true }, users: { exclude: true } },
+    });
+    expect(out).not.toContain("CommentsRelations");
+    expect(out).not.toContain("BuildExpand");
+    expect(out).not.toContain("Split");
+    expect(out).toContain("getComment(id: string, options?: RequestOptions");
+  });
+
   test("skips disabled operations", () => {
     const partial = generateSdk(ir, {
       collections: { articles: { operations: { create: false, delete: false } } },
     });
     expect(partial).not.toContain("createArticle(");
     expect(partial).not.toContain("deleteArticle(");
-    expect(partial).toContain("getArticle(");
+    expect(partial).toContain("getArticle<");
     expect(partial).toContain("updateArticle(");
   });
 
-  test("imports Expand types for collections with relations", () => {
-    expect(output).toContain("ArticlesExpand");
-    expect(output).toContain("CommentsExpand");
+  test("imports Relations maps and expand helpers for collections with relations", () => {
+    expect(output).toContain("ArticlesRelations");
+    expect(output).toContain("CommentsRelations");
+    expect(output).toContain("BuildExpand");
+    expect(output).toContain("Split");
   });
 
-  test("uses typed expand in CRUD functions for collections with relations", () => {
+  test("read functions are generic over the expand string for collections with relations", () => {
     const getFn = output.slice(
       output.indexOf("export async function getArticle"),
-      output.indexOf("}", output.indexOf("export async function getArticle")) + 1,
+      output.indexOf("{\n", output.indexOf("export async function getArticle")),
     );
-    expect(getFn).toContain('Omit<RequestOptions, "expand"> & { expand?: ArticlesExpand }');
+    expect(getFn).toContain("getArticle<const S extends string | undefined = undefined>");
+    expect(getFn).toContain('options?: Omit<RequestOptions, "expand"> & { expand?: S }');
+    expect(getFn).toContain(
+      "Promise<ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {})>",
+    );
+  });
+
+  test("list functions thread the expand generic through ListParams", () => {
+    const listFn = output.slice(
+      output.indexOf("export async function listArticles"),
+      output.indexOf("{\n", output.indexOf("export async function listArticles")),
+    );
+    expect(listFn).toContain('params?: Omit<ListParams, "expand"> & { expand?: S }');
+    expect(listFn).toContain(
+      "Promise<ListResult<ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {})>>",
+    );
+  });
+
+  test("getFullList parenthesizes the intersection before the array", () => {
+    const fn = output.slice(
+      output.indexOf("export async function getFullListArticles"),
+      output.indexOf("{\n", output.indexOf("export async function getFullListArticles")),
+    );
+    expect(fn).toContain(
+      "Promise<(ArticlesRecord & (S extends string ? { expand?: BuildExpand<ArticlesRelations, Split<S>> } : {}))[]>",
+    );
+  });
+
+  test("read functions stay non-generic for collections without relations", () => {
+    expect(output).toContain("export async function getCategory(id: string, options?: RequestOptions");
+    expect(output).not.toContain("getCategory<");
   });
 
   test("uses plain RequestOptions for collections without relations", () => {

--- a/packages/pbkit/src/test/type-generator.test.ts
+++ b/packages/pbkit/src/test/type-generator.test.ts
@@ -233,4 +233,26 @@ describe("generate", () => {
     expect(commentsExpand).toContain('"article"')
     expect(commentsExpand).toContain('"author"')
   })
+
+  test("generates a relations map for collections with forward relations", () => {
+    const output = generate(ir)
+    expect(output).toContain("export type ArticlesRelations = {")
+    expect(output).toContain('author: { rec: UsersRecord; coll: "users"; multi: false }')
+    expect(output).toContain('categories: { rec: CategoriesRecord; coll: "categories"; multi: true }')
+  })
+
+  test("skips relations map for collections without forward relations", () => {
+    const output = generate(ir)
+    expect(output).not.toContain("CategoriesRelations")
+    expect(output).not.toContain("UsersRelations")
+  })
+
+  test("emits the global RelationsMap and expand helpers once", () => {
+    const output = generate(ir)
+    expect(output).toContain("type RelationsMap = {")
+    expect(output).toContain('"users": {}')
+    expect(output).toContain('"articles": ArticlesRelations')
+    expect(output).toContain("export type BuildExpand<R, P extends string>")
+    expect(output).toContain("type Split<S extends string>")
+  })
 })

--- a/packages/pbkit/src/test/type-generator.test.ts
+++ b/packages/pbkit/src/test/type-generator.test.ts
@@ -234,6 +234,19 @@ describe("generate", () => {
     expect(commentsExpand).toContain('"author"')
   })
 
+  test("omits expand paths into excluded target collections (keeps XxxExpand and XxxRelations consistent)", () => {
+    const output = generate(ir, { collections: { users: { exclude: true } } })
+    // articles.author -> users (excluded): must not appear in either representation
+    const articlesExpand = output.match(/export type ArticlesExpand = (.+)/)?.[1]
+    expect(articlesExpand).not.toContain('"author"')
+    expect(articlesExpand).toContain('"categories"')
+    expect(output).not.toContain('author: { rec: UsersRecord')
+    // comments.author -> users (excluded), incl. the nested article.author path
+    const commentsExpand = output.match(/export type CommentsExpand = (.+)/)?.[1]
+    expect(commentsExpand).not.toContain('"author"')
+    expect(commentsExpand).not.toContain('"article.author"')
+  })
+
   test("generates a relations map for collections with forward relations", () => {
     const output = generate(ir)
     expect(output).toContain("export type ArticlesRelations = {")

--- a/packages/pbkit/src/type-generator/generate.ts
+++ b/packages/pbkit/src/type-generator/generate.ts
@@ -135,6 +135,45 @@ function expandType(col: CollectionSchema, ir: SchemaIR, maxDepth: number): stri
   return `export type ${name}Expand = ${union}`
 }
 
+// Forward relations of a collection whose target is generated, used to build
+// the typed `.expand` result shape. Returns null when there are none.
+function relationsMapType(
+  col: CollectionSchema,
+  ir: SchemaIR,
+  isExcluded: (name: string) => boolean,
+): string | null {
+  const rels = ir.relations.filter(
+    r => r.collectionName === col.name && !isExcluded(r.targetCollectionName),
+  )
+  if (rels.length === 0) return null
+  const name = pascalCase(col.name)
+  const entries = rels.map(r => {
+    const rec = `${pascalCase(r.targetCollectionName)}Record`
+    const coll = JSON.stringify(r.targetCollectionName)
+    return `  ${r.fieldName}: { rec: ${rec}; coll: ${coll}; multi: ${r.multiple} }`
+  })
+  return `export type ${name}Relations = {\n${entries.join("\n")}\n}`
+}
+
+// Hand-authored generic machinery (emitted once) that parses a PocketBase
+// comma-separated expand string literal into the nested `.expand` result shape.
+const EXPAND_HELPERS = `type Trim<S extends string> = S extends \` \${infer R}\` ? Trim<R> : S extends \`\${infer R} \` ? Trim<R> : S
+type Split<S extends string> = S extends \`\${infer H},\${infer T}\` ? Trim<H> | Split<T> : Trim<S>
+type Head<P extends string> = P extends \`\${infer H}.\${string}\` ? H : P
+type Under<P extends string, K extends string> = P extends \`\${K}.\${infer R}\` ? R : never
+type RelEntry = { rec: unknown; coll: keyof RelationsMap; multi: boolean }
+type ExpandValue<E extends RelEntry, Rest extends string> = [Rest] extends [never]
+  ? E["rec"]
+  : E["rec"] & { expand?: BuildExpand<RelationsMap[E["coll"]], Rest> }
+export type BuildExpand<R, P extends string> = {
+  [K in Head<P> & keyof R]: R[K] extends RelEntry
+    ? R[K]["multi"] extends true
+      ? ExpandValue<R[K], Under<P, K>>[]
+      : ExpandValue<R[K], Under<P, K>>
+    : never
+}
+export type { Split }`
+
 export function generate(ir: SchemaIR, options: GenerateOptions & { collections?: CollectionsConfig } = {}): string {
   const opts: GenerateOptions = {
     dateStrings: options.dateStrings ?? true,
@@ -143,7 +182,15 @@ export function generate(ir: SchemaIR, options: GenerateOptions & { collections?
   }
   const expandDepth = options.expandDepth ?? 2
 
-  const cols = ir.collections.filter(c => !isCollectionExcluded(c.name, options.collections))
+  const isExcluded = (name: string) => isCollectionExcluded(name, options.collections)
+  const cols = ir.collections.filter(c => !isExcluded(c.name))
+
+  const relationsMaps = new Map<string, string>()
+  for (const col of cols) {
+    const rm = relationsMapType(col, ir, isExcluded)
+    if (rm) relationsMaps.set(col.name, rm)
+  }
+  const hasAnyRelations = relationsMaps.size > 0
 
   const parts: string[] = []
 
@@ -183,6 +230,21 @@ export function generate(ir: SchemaIR, options: GenerateOptions & { collections?
       parts.push(exp)
       parts.push("")
     }
+    const rm = relationsMaps.get(col.name)
+    if (rm) {
+      parts.push(rm)
+      parts.push("")
+    }
+  }
+
+  if (hasAnyRelations) {
+    const mapEntries = cols
+      .map(c => `  ${JSON.stringify(c.name)}: ${relationsMaps.has(c.name) ? `${pascalCase(c.name)}Relations` : "{}"}`)
+      .join("\n")
+    parts.push(`type RelationsMap = {\n${mapEntries}\n}`)
+    parts.push("")
+    parts.push(EXPAND_HELPERS)
+    parts.push("")
   }
 
   const names = cols.map(c => JSON.stringify(c.name)).join(" | ")

--- a/packages/pbkit/src/type-generator/generate.ts
+++ b/packages/pbkit/src/type-generator/generate.ts
@@ -100,6 +100,7 @@ function getExpandPaths(
   maxDepth: number,
   depth: number,
   visited: Set<string>,
+  isExcluded: (name: string) => boolean,
 ): string[] {
   if (depth >= maxDepth || visited.has(collectionName)) return []
   visited.add(collectionName)
@@ -111,15 +112,18 @@ function getExpandPaths(
 
   for (const field of col.fields) {
     if (field.type !== "relation") continue
-    paths.push(field.name)
 
     const targetName = ir.collections.find(
       c => c.id === field.options.collectionId,
     )?.name
+    // Don't advertise a path into an excluded collection: its XxxRecord isn't
+    // generated, and XxxRelations omits it, so the two would disagree.
+    if (targetName && isExcluded(targetName)) continue
+    paths.push(field.name)
     if (!targetName) continue
 
     const nextVisited = new Set(visited)
-    for (const deep of getExpandPaths(ir, targetName, maxDepth, depth + 1, nextVisited)) {
+    for (const deep of getExpandPaths(ir, targetName, maxDepth, depth + 1, nextVisited, isExcluded)) {
       paths.push(`${field.name}.${deep}`)
     }
   }
@@ -127,8 +131,13 @@ function getExpandPaths(
   return paths
 }
 
-function expandType(col: CollectionSchema, ir: SchemaIR, maxDepth: number): string | null {
-  const paths = getExpandPaths(ir, col.name, maxDepth, 0, new Set())
+function expandType(
+  col: CollectionSchema,
+  ir: SchemaIR,
+  maxDepth: number,
+  isExcluded: (name: string) => boolean,
+): string | null {
+  const paths = getExpandPaths(ir, col.name, maxDepth, 0, new Set(), isExcluded)
   if (paths.length === 0) return null
   const name = pascalCase(col.name)
   const union = paths.map(p => JSON.stringify(p)).join(" | ")
@@ -225,7 +234,7 @@ export function generate(ir: SchemaIR, options: GenerateOptions & { collections?
     parts.push("")
     parts.push(`export type ${name}Update = Partial<${name}Create>`)
     parts.push("")
-    const exp = expandType(col, ir, expandDepth)
+    const exp = expandType(col, ir, expandDepth, isExcluded)
     if (exp) {
       parts.push(exp)
       parts.push("")

--- a/skills/pbkit/SKILL.md
+++ b/skills/pbkit/SKILL.md
@@ -11,7 +11,7 @@ Use pbkit when a project needs type-safe TypeScript access to a PocketBase backe
 
 ## What pbkit Generates
 
-- `types.gen.ts`: TypeScript types for each non-excluded collection, including `XxxRecord`, `XxxCreate`, `XxxUpdate`, `XxxExpand`, and `CollectionName`.
+- `types.gen.ts`: TypeScript types for each non-excluded collection, including `XxxRecord`, `XxxCreate`, `XxxUpdate`, `XxxExpand`, `XxxRelations` (the map powering typed `.expand` results), and `CollectionName`.
 - `client.gen.ts`: Default PocketBase client singleton and `PbClient` type export.
 - `sdk.gen.ts`: Typed CRUD functions using the singleton client (with optional per-call override).
 - `realtime.gen.ts`: Typed realtime subscription helpers when using `@karnak19/pbkit-realtime`.
@@ -172,6 +172,7 @@ const article = await getArticle("RECORD_ID")
 const articleWithAuthor = await getArticle("RECORD_ID", {
   expand: "author",
 })
+// articleWithAuthor.expand?.author is typed as UsersRecord
 
 const page = await listArticles({
   page: 1,
@@ -341,7 +342,7 @@ export default {
 - Install `pocketbase` in the consuming app; `client.gen.ts` imports it unless `sdk.pbImport` is customized.
 - Do not edit generated files directly. Update `pbkit.config.ts` or the PocketBase schema, then rerun generation.
 - Treat PocketBase date values as strings unless the project explicitly sets `types.dateStrings: false`.
-- Expand types are string unions generated up to `types.expandDepth`; increase the depth only when deeper relation paths are needed.
+- Expand: read functions for collections with relations are generic over the `expand` string, so `record.expand?.x` is typed (single relation → record, multi → array, nested paths nest). The `expand` input is a plain string (no autocomplete); the `XxxExpand` union is still generated for reference. `XxxExpand` paths are generated up to `types.expandDepth`. Reverse `_via_` back-relations are not yet typed.
 - Excluded collections produce no types, SDK functions, or plugin output.
 - Disabled operations remove the corresponding SDK functions and TanStack mutation/query helpers.
 - PocketBase filters are still PocketBase filter strings; pbkit types function parameters but does not validate filter syntax.
@@ -356,7 +357,7 @@ When a project already uses [pocketbase-typegen](https://github.com/patmood/pock
 - Replace CLI flags with `pbkit.config.ts`. Flag mapping: `--url/--email/--password` → `input: { url, token }`; `--url` (public) → `input: "<url>"`; `--json <file>` → `input: "<file>"`. `--db <sqlite>` is **not** supported via config — switch to a URL or exported JSON. `--out <file>` → `output: "<dir>"` (a directory, cleared on each run).
 - Type name mapping: `XxxResponse` → `XxxRecord`; `XxxRecord` (input shape) → `XxxCreate` / `XxxUpdate`; `Collections` enum → `CollectionName` union; per-field `XxxStatusOptions` enums → inline string literal unions; `BaseSystemFields` → `BaseRecord`; `AuthSystemFields` → `AuthRecord`.
 - Call-site mapping: `pb.collection("articles").getOne(id)` → `getArticle(id)`; `.getFirstListItem(filter)` → `getFirstArticle(filter)`; `.getList(page, perPage)` → `listArticles({ page, perPage })`; `.getFullList()` → `getFullListArticles()`; `.create(data)` → `createArticle(data)`; `.update(id, data)` → `updateArticle(id, data)`; `.delete(id)` → `deleteArticle(id)`. Auth: `pb.collection("users").authWithPassword(...)` → `authUserWithPassword(...)`.
-- Expand no longer needs manual generics — the `expand` option is typed from the schema. Delete the `TypedPocketBase` cast and the old `pocketbase-types.ts` once imports are updated.
+- Expand no longer needs manual generics — `record.expand.x` is typed automatically from the `expand` string you pass. Delete the `TypedPocketBase` cast and the old `pocketbase-types.ts` once imports are updated.
 
 ## Agent Workflow
 


### PR DESCRIPTION
Closes #37.

## Problem

The SDK constrained the expand **input** (`XxxExpand` dot-path union) but the **result** had no typed `.expand` — records were scalar-only and read functions had a fixed return type. After requesting an expand, consuming `record.expand.x` was a type error. This was the main blocker for migrating a real app (AirsoftOne, ~258 `record.expand.x` reads) off `pocketbase-typegen`.

## Solution

Read functions (`getX`, `getFirstX`, `listX`, `getFullListX`) for collections with relations are now **generic over the requested expand string**, and the result carries a typed `.expand` matching exactly what was asked for:

```ts
const a = await getArticle(id, { expand: "author,categories" })
a.expand?.author     // UsersRecord
a.expand?.categories // CategoriesRecord[]   (multi-relation → array)

const c = await getComment(id, { expand: "article.author" })
c.expand?.article.expand?.author // UsersRecord  (nested)

await getArticle(id) // no expand → no required `.expand`
```

### How

- **Type generator** emits, per collection with forward relations, an `XxxRelations` map (`{ field: { rec; coll; multi } }`), a global `RelationsMap` index, and a shared block of helper types (`Split`, `Head`, `Under`, `BuildExpand`, `ExpandValue`). The existing `XxxExpand` union is still generated.
- **SDK generator** threads `<const S extends string>` through the read signatures: `Promise<XxxRecord & (S extends string ? { expand?: BuildExpand<XxxRelations, Split<S>> } : {})>`. Collections without relations are unchanged.

### Decisions / tradeoffs

- **Input stays the native comma-separated string** (`"a,b"`) so existing call sites are untouched. The cost: the result is inferred from the literal, so the `expand` **input** is now a plain `string` (no autocomplete). The `XxxExpand` union remains exported for reference/validation.
- **Reverse (`_via_`) back-relations are deferred** to a follow-up.
- `.expand` is **optional** on the result (PocketBase omits empty/unauthorized relations).

## Verification

- **Compile-time acceptance test** (`expand-typecheck.test.ts`): generates the types into a temp dir and runs `tsc` over type-level assertions for single / multi / multi-path / nested expands, plus a self-validating `@ts-expect-error` negative case — so the assertions can never drift from the generator.
- Regression test for the excluded-target edge case (see below).
- Updated unit tests + snapshots. Full `bun run ci` green (lint, typecheck, test, build across all packages + docs).

## Notes

- Self-review caught one bug, now fixed: `hasRelationsMap()` in the SDK generator wasn't applying the same exclusion filter as the type generator, so a collection whose relation targets were *all* excluded produced an SDK importing an `XxxRelations`/`BuildExpand`/`Split` that `types.gen.ts` never emitted. Aligned both generators + added a regression test.
- TanStack Query plugin still returns fixed types (threading the generic into generated hooks is a clean follow-up).
- Docs updated (`reference/expand-types`, `reference/generated-sdk`, `explanation/relations-and-expand`, migration how-to) + `skills/pbkit/SKILL.md`. Changeset: `@karnak19/pbkit` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)