### PR TITLE
fix: declare @karnak19/pbkit as peer dependency on plugins

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/plugin-peer-deps.md
+++ b/.changeset/plugin-peer-deps.md
@@ -1,0 +1,7 @@
+---
+"@karnak19/pbkit-tanstack": patch
+"@karnak19/pbkit-zod": patch
+"@karnak19/pbkit-realtime": patch
+---
+
+Fix uninstallable plugins by moving `@karnak19/pbkit` from `dependencies` (`workspace:*`) to `peerDependencies` (`^0.4.0`). The unresolved `workspace:*` protocol was being published verbatim, so the plugins couldn't be installed outside the monorepo. The core package is now declared as a peer dependency — consumers already install it as the host CLI — which also guarantees the plugin shares the host's single pbkit instance.

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
     },
     "packages/pbkit": {
       "name": "@karnak19/pbkit",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "bin": {
         "pbkit": "./dist/cli/index.js",
       },
@@ -44,44 +44,41 @@
     },
     "packages/pbkit-realtime": {
       "name": "@karnak19/pbkit-realtime",
-      "version": "0.0.0",
-      "dependencies": {
-        "@karnak19/pbkit": "workspace:*",
-      },
+      "version": "0.1.1",
       "devDependencies": {
+        "@karnak19/pbkit": "workspace:*",
         "@types/bun": "^1.3.13",
         "typescript": "^6.0.0",
       },
       "peerDependencies": {
+        "@karnak19/pbkit": "^0.4.0",
         "pocketbase": ">=0.21.0",
       },
     },
     "packages/pbkit-tanstack": {
       "name": "@karnak19/pbkit-tanstack",
-      "version": "0.2.0",
-      "dependencies": {
-        "@karnak19/pbkit": "workspace:*",
-      },
+      "version": "0.2.2",
       "devDependencies": {
+        "@karnak19/pbkit": "workspace:*",
         "@types/bun": "^1.3.13",
         "typescript": "^6.0.0",
       },
       "peerDependencies": {
+        "@karnak19/pbkit": "^0.4.0",
         "@tanstack/query-core": "^5.0.0",
       },
     },
     "packages/pbkit-zod": {
       "name": "@karnak19/pbkit-zod",
-      "version": "0.0.2",
-      "dependencies": {
-        "@karnak19/pbkit": "workspace:*",
-      },
+      "version": "0.0.4",
       "devDependencies": {
+        "@karnak19/pbkit": "workspace:*",
         "@types/bun": "^1.3.13",
         "typescript": "^6.0.0",
         "zod": "^3.25.0",
       },
       "peerDependencies": {
+        "@karnak19/pbkit": "^0.4.0",
         "zod": "^3.0.0",
       },
     },

--- a/packages/pbkit-realtime/package.json
+++ b/packages/pbkit-realtime/package.json
@@ -37,12 +37,11 @@
   },
   "license": "MIT",
   "peerDependencies": {
+    "@karnak19/pbkit": "^0.4.0",
     "pocketbase": ">=0.21.0"
   },
-  "dependencies": {
-    "@karnak19/pbkit": "workspace:*"
-  },
   "devDependencies": {
+    "@karnak19/pbkit": "workspace:*",
     "@types/bun": "^1.3.13",
     "typescript": "^6.0.0"
   }

--- a/packages/pbkit-tanstack/package.json
+++ b/packages/pbkit-tanstack/package.json
@@ -37,12 +37,11 @@
   },
   "license": "MIT",
   "peerDependencies": {
+    "@karnak19/pbkit": "^0.4.0",
     "@tanstack/query-core": "^5.0.0"
   },
-  "dependencies": {
-    "@karnak19/pbkit": "workspace:*"
-  },
   "devDependencies": {
+    "@karnak19/pbkit": "workspace:*",
     "@types/bun": "^1.3.13",
     "typescript": "^6.0.0"
   }

--- a/packages/pbkit-zod/package.json
+++ b/packages/pbkit-zod/package.json
@@ -37,12 +37,11 @@
   },
   "license": "MIT",
   "peerDependencies": {
+    "@karnak19/pbkit": "^0.4.0",
     "zod": "^3.0.0"
   },
-  "dependencies": {
-    "@karnak19/pbkit": "workspace:*"
-  },
   "devDependencies": {
+    "@karnak19/pbkit": "workspace:*",
     "@types/bun": "^1.3.13",
     "typescript": "^6.0.0",
     "zod": "^3.25.0"


### PR DESCRIPTION
Closes #42

## Problem

The three plugin packages shipped `"@karnak19/pbkit": "workspace:*"` in their **published** `dependencies`. The `workspace:` protocol is only rewritten to a real range at publish time by pnpm/yarn — but releases go through `changeset publish` → `npm publish`, and npm leaves the literal `workspace:*` in place. Result: all three plugins were uninstallable from the registry.

## Fix

Move `@karnak19/pbkit` from `dependencies` (`workspace:*`) to **`peerDependencies`** (`^0.4.0`), and keep `workspace:*` in `devDependencies` so local builds/tests still link the workspace copy.

Peer dependency is the right model here: the plugins are loaded by the host pbkit CLI and receive host-created `PluginContext` objects, so they must share the host's single core instance. Consumers always install `@karnak19/pbkit` anyway (it's the CLI driving generation).

Also added `onlyUpdatePeerDependentsWhenOutOfRange: true` to `.changeset/config.json` so changesets only bumps the plugins when a core release actually crosses the peer-range boundary (not on every in-range patch).

## Changes

- `packages/pbkit-{tanstack,zod,realtime}/package.json` — core → `peerDependencies: ^0.4.0`, `workspace:*` retained in `devDependencies`
- `.changeset/config.json` — `onlyUpdatePeerDependentsWhenOutOfRange: true`
- changeset (patch) documenting the fix

## Verification

- `bun run ci` — all 17 tasks pass (lint/typecheck/test/build); plugins still resolve core via the workspace devDep.
- `npm pack --dry-run` + manifest inspection: published `dependencies`/`peerDependencies` contain **no** `workspace:` protocol — only `peerDependencies: { "@karnak19/pbkit": "^0.4.0", ... }`.
- Full registry verification (`bun add -D @karnak19/pbkit-tanstack` in a fresh project) is post-publish, once a release ships these manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)