### PR TITLE
fix: include passwordConfirm/oldPassword in auth Create/Update types

### DIFF
--- a/.changeset/auth-password-confirm-types.md
+++ b/.changeset/auth-password-confirm-types.md
@@ -1,0 +1,23 @@
+---
+"@karnak19/pbkit": minor
+---
+
+Generate the password-confirmation fields that PocketBase's auth API requires (#53).
+
+For auth collections, the generated request types now include:
+
+- `Create`: a required `passwordConfirm: string` alongside `password`.
+- `Update`: an optional `oldPassword?: string` (and `passwordConfirm?` via `Partial<Create>`), for self-service password changes.
+
+```ts
+export type UsersCreate = {
+  password: string
+  passwordConfirm: string
+  // ...
+}
+export type UsersUpdate = Partial<UsersCreate> & {
+  oldPassword?: string
+}
+```
+
+`createUser({ email, password, passwordConfirm })` now typechecks without a cast, and password-change updates accept `{ oldPassword, password, passwordConfirm }`. Non-auth collections are unaffected.

--- a/packages/pbkit/src/test/__snapshots__/type-generator.test.ts.snap
+++ b/packages/pbkit/src/test/__snapshots__/type-generator.test.ts.snap
@@ -44,6 +44,7 @@ export type UsersRecord = AuthRecord & {
 
 export type UsersCreate = {
   password: string
+  passwordConfirm: string
   email: string
   emailVisibility?: boolean
   verified?: boolean
@@ -51,7 +52,9 @@ export type UsersCreate = {
   avatar?: string
 }
 
-export type UsersUpdate = Partial<UsersCreate>
+export type UsersUpdate = Partial<UsersCreate> & {
+  oldPassword?: string
+}
 
 // Categories
 

--- a/packages/pbkit/src/test/type-generator.test.ts
+++ b/packages/pbkit/src/test/type-generator.test.ts
@@ -113,6 +113,36 @@ describe("generate", () => {
     expect(output).toContain("export type ArticlesUpdate = Partial<ArticlesCreate> & {")
   })
 
+  // Regression (#53): PocketBase auth API requires passwordConfirm on create and
+  // accepts oldPassword on a self-service password-change update.
+  test("auth Create includes a required passwordConfirm next to password", () => {
+    const output = generate(ir)
+    const usersCreate = output.slice(
+      output.indexOf("export type UsersCreate"),
+      output.indexOf("export type UsersUpdate"),
+    )
+    expect(usersCreate).toContain("password: string")
+    expect(usersCreate).toContain("passwordConfirm: string")
+    expect(usersCreate).not.toContain("passwordConfirm?:")
+  })
+
+  test("auth Update adds oldPassword (passwordConfirm comes via Partial<Create>)", () => {
+    const output = generate(ir)
+    const usersUpdate = output.match(/export type UsersUpdate = [^\n]+(?:\n {2}[^\n]+)*\n}/)?.[0] ?? ""
+    expect(usersUpdate).toContain("Partial<UsersCreate> & {")
+    expect(usersUpdate).toContain("oldPassword?: string")
+  })
+
+  test("non-auth collections get no passwordConfirm/oldPassword", () => {
+    const output = generate(ir)
+    const articles = output.slice(
+      output.indexOf("// Articles"),
+      output.indexOf("// Comments"),
+    )
+    expect(articles).not.toContain("passwordConfirm")
+    expect(articles).not.toContain("oldPassword")
+  })
+
   test("skips password in Record, includes in Create for auth", () => {
     const output = generate(ir)
     const usersRecord = output.slice(
@@ -212,9 +242,8 @@ describe("generate", () => {
     expect(articlesUpdate).toContain('"attachments-"?: string | string[]')
   })
 
-  test("keeps plain Partial Update for collections without multi relation/file fields", () => {
+  test("keeps plain Partial Update for non-auth collections without multi relation/file fields", () => {
     const output = generate(ir)
-    expect(output).toContain("export type UsersUpdate = Partial<UsersCreate>")
     expect(output).toContain("export type CategoriesUpdate = Partial<CategoriesCreate>")
   })
 

--- a/packages/pbkit/src/type-generator/generate.ts
+++ b/packages/pbkit/src/type-generator/generate.ts
@@ -93,9 +93,14 @@ function recordType(collection: CollectionSchema, options: InternalOptions): str
 
 function createType(collection: CollectionSchema, options: InternalOptions): string {
   const name = pascalCase(collection.name)
-  const fields = collection.fields
-    .filter(f => isCreateField(f))
-    .map(f => "  " + fieldDecl(f, options, collection.name))
+  const isAuth = collection.type === "auth"
+  const fields: string[] = []
+  for (const f of collection.fields) {
+    if (!isCreateField(f)) continue
+    fields.push("  " + fieldDecl(f, options, collection.name))
+    // PocketBase requires passwordConfirm alongside password on auth create.
+    if (isAuth && f.type === "password") fields.push("  passwordConfirm: string")
+  }
 
   if (fields.length === 0) return `export type ${name}Create = Record<string, unknown>`
   return `export type ${name}Create = {\n${fields.join("\n")}\n}`
@@ -110,19 +115,23 @@ function isModifierField(field: CollectionField): boolean {
 
 function updateType(collection: CollectionSchema): string {
   const name = pascalCase(collection.name)
-  const modFields = collection.fields.filter(isModifierField)
-  if (modFields.length === 0) return `export type ${name}Update = Partial<${name}Create>`
+  const extra: string[] = []
 
-  const mods: string[] = []
-  for (const f of modFields) {
+  // A user changing their own auth password must also supply oldPassword;
+  // passwordConfirm is already covered as optional by Partial<Create>.
+  if (collection.type === "auth") extra.push("  oldPassword?: string")
+
+  for (const f of collection.fields.filter(isModifierField)) {
     // file append/prepend take uploads (File), removal takes filenames (string);
     // relation modifiers are all record-id strings.
     const append = f.type === "file" ? "File | File[]" : "string | string[]"
-    mods.push(`  ${JSON.stringify("+" + f.name)}?: ${append}`)
-    mods.push(`  ${JSON.stringify(f.name + "+")}?: ${append}`)
-    mods.push(`  ${JSON.stringify(f.name + "-")}?: string | string[]`)
+    extra.push(`  ${JSON.stringify("+" + f.name)}?: ${append}`)
+    extra.push(`  ${JSON.stringify(f.name + "+")}?: ${append}`)
+    extra.push(`  ${JSON.stringify(f.name + "-")}?: string | string[]`)
   }
-  return `export type ${name}Update = Partial<${name}Create> & {\n${mods.join("\n")}\n}`
+
+  if (extra.length === 0) return `export type ${name}Update = Partial<${name}Create>`
+  return `export type ${name}Update = Partial<${name}Create> & {\n${extra.join("\n")}\n}`
 }
 
 function getExpandPaths(


### PR DESCRIPTION
Closes #53.

## Problem

For auth collections, the generated `Create`/`Update` types omitted the password-confirmation fields PocketBase requires at runtime, forcing consumers to cast:

```ts
await createUser({ email, password, passwordConfirm, ... } as UsersCreate & { passwordConfirm: string }, { client: pb });
```

## Fix

For auth-type collections only, the generated request types now include:

- `Create`: a required `passwordConfirm: string` alongside `password`.
- `Update`: an optional `oldPassword?: string`. `passwordConfirm?` is already covered by `Partial<Create>`.

```ts
export type UsersCreate = {
  password: string
  passwordConfirm: string
  // ...
}
export type UsersUpdate = Partial<UsersCreate> & {
  oldPassword?: string
}
```

These flow through to the SDK automatically — `create${S}` takes `${P}Create` and `update${S}` takes `${P}Update`.

## Acceptance

- ✅ `createUser({ email, password, passwordConfirm })` typechecks without a cast.
- ✅ A password-change update accepts `{ oldPassword, password, passwordConfirm }`.
- ✅ Non-auth collections are unaffected.

## Tests

Added regression tests covering auth Create's required `passwordConfirm`, auth Update's `oldPassword`, and non-auth collections staying clean. Snapshot updated. Full suite: 203 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)