### PR TITLE
chore: release pbkit 1.0.0

### DIFF
--- a/.changeset/pbkit-1-0-0.md
+++ b/.changeset/pbkit-1-0-0.md
@@ -1,0 +1,5 @@
+---
+"@karnak19/pbkit": major
+---
+
+Release 1.0.0. pbkit's core surface — the `PbkitConfig` schema, the generated `types.gen.ts`/`sdk.gen.ts`/`client.gen.ts`, the programmatic API (`generateProject`, `generate`, `generateSdk`, schema parsers), and the plugin contract (`PbkitPlugin`/`PluginContext`) — is now considered stable and follows semver going forward.


### PR DESCRIPTION
Promotes `@karnak19/pbkit` to its first stable release.

Adds a `major` changeset for `@karnak19/pbkit`. Changesets bumps `0.6.0 → 1.0.0` on a major, so once this merges the open **Version Packages** PR (#55) will publish **pbkit 1.0.0** instead of 0.7.0.

The core surface — `PbkitConfig`, the generated `types.gen.ts`/`sdk.gen.ts`/`client.gen.ts`, the programmatic API, and the plugin contract — is now considered stable and follows semver.

Plugins keep their own independent versions (verified via a `changeset version` dry run): zod 3.0.0, tanstack 4.0.0, realtime 3.0.0.

**Merge this before #55** so the release PR regenerates at 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)