### PR TITLE
feat(cli): add `pbkit schema` subcommand for schema management

### DIFF
--- a/.changeset/schema-cli-subcommand.md
+++ b/.changeset/schema-cli-subcommand.md
@@ -1,0 +1,13 @@
+---
+"@karnak19/pbkit": minor
+---
+
+Add a `pbkit schema` CLI subcommand for managing PocketBase collection
+definitions against the admin API. Supports `list`, `get`, `pull`, `apply`,
+`add-field`, `add-index`, `set-rule`, and `create-view`. Authenticates as a
+superuser via env vars (`POCKETBASE_URL`, `POCKETBASE_ADMIN_EMAIL`,
+`POCKETBASE_ADMIN_PASSWORD`, `POCKETBASE_ADMIN_TOKEN`) with fallback to the
+pbkit config. `pull` produces the same snapshot shape the generator consumes;
+`apply` is non-destructive by default; partial operations fetch-and-patch so
+they never clobber unrelated fields, indexes, or rules. Schema-only — record
+mutation is intentionally out of scope.

--- a/apps/docs/src/content/docs/how-to/manage-schema.md
+++ b/apps/docs/src/content/docs/how-to/manage-schema.md
@@ -1,0 +1,87 @@
+---
+title: Manage schema from the CLI
+description: Use `pbkit schema` to read and edit PocketBase collections without hand-rolled curl.
+sidebar:
+  order: 8
+---
+
+The `pbkit schema` subcommand manages collection definitions directly against
+the PocketBase admin API, so schema changes don't require hand-rolled `curl`
+calls. It is schema-only — record create/update/delete is intentionally out of
+scope.
+
+## Authenticate
+
+Schema commands authenticate as a superuser. Set credentials in the environment
+(preferred) — they are never passed inline:
+
+```bash
+export POCKETBASE_URL="https://my-pb.example.com"
+export POCKETBASE_ADMIN_EMAIL="admin@example.com"
+export POCKETBASE_ADMIN_PASSWORD="••••••••"
+```
+
+If you already have an admin token, use `POCKETBASE_ADMIN_TOKEN` instead of the
+email/password pair. When env vars are absent, pbkit falls back to the API
+`input` (`url`/`token`) in your `pbkit.config.ts`.
+
+## Inspect the schema
+
+```bash
+pbkit schema list            # every collection: name + type
+pbkit schema get posts       # one collection as JSON (fields, indexes, rules)
+```
+
+## Pull a snapshot and generate
+
+`pull` writes exactly the shape `pbkit generate` reads, so you can snapshot a
+live instance and generate types from the file:
+
+```bash
+pbkit schema pull --out pb-schema.json
+pbkit generate   # with input: "./pb-schema.json"
+```
+
+## Apply definitions
+
+`apply` imports collection definitions. It is non-destructive by default
+(`deleteMissing: false`) — existing collections not present in the file are left
+alone. Pass `--delete-missing` to mirror the file exactly.
+
+```bash
+pbkit schema apply pb-schema.json
+pbkit schema apply pb-schema.json --delete-missing   # destructive
+```
+
+## Patch a single collection
+
+These operations fetch the current collection and patch it, so they never
+clobber unrelated fields, indexes, or rules.
+
+```bash
+# Add a field (the rest of the fields array is preserved)
+pbkit schema add-field posts '{"name":"slug","type":"text","required":true}'
+
+# Add an index (merged with existing indexes, not overwritten)
+pbkit schema add-index posts "CREATE UNIQUE INDEX idx_slug ON posts (slug)"
+
+# Update API rules (only the rules you pass are changed)
+pbkit schema set-rule posts \
+  --list "@request.auth.id != ''" \
+  --create "@request.auth.id != ''"
+```
+
+For `set-rule`, a value of `"null"` makes the rule superuser-only and `""`
+makes it public:
+
+```bash
+pbkit schema set-rule posts --delete null   # superuser-only
+pbkit schema set-rule posts --view ""       # public
+```
+
+## Create a view collection
+
+```bash
+pbkit schema create-view active_users \
+  --query "SELECT id FROM users WHERE verified = true"
+```

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -23,6 +23,64 @@ bunx pbkit generate
 | `--watch` | `-w` | Watch mode — regenerates every 10 seconds |
 | `--help` | `-h` | Show help message |
 
+### `pbkit schema`
+
+Manage PocketBase collection definitions directly against the admin API
+(`/api/collections`). Schema-only — record CRUD is intentionally out of scope.
+
+```bash
+pbkit schema list                       # list all collections (name + type)
+pbkit schema get <collection>           # dump one collection as JSON
+pbkit schema pull [--out pb-schema.json]# download the full snapshot the generator reads
+pbkit schema apply <file.json>          # import definitions (non-destructive)
+pbkit schema add-field <collection> <json>
+pbkit schema add-index <collection> "<sql>"
+pbkit schema set-rule <collection> [--list <rule>] [--view <rule>] [--create <rule>] [--update <rule>] [--delete <rule>]
+pbkit schema create-view <name> --query "<sql>"
+```
+
+#### Subcommands
+
+| Command | Description |
+|---|---|
+| `list` | List every collection with its name and type |
+| `get <collection>` | Print one collection (fields, indexes, rules, viewQuery) as JSON |
+| `pull [--out <file>]` | Write the full schema snapshot (default `pb-schema.json`) — the same shape `pbkit generate` consumes |
+| `apply <file>` | Import collection definitions via `PUT /api/collections/import` |
+| `add-field <collection> <json>` | Append a field, preserving the existing `fields` array |
+| `add-index <collection> "<sql>"` | Append an index, merging with existing indexes |
+| `set-rule <collection> --list/--view/--create/--update/--delete <rule>` | Update API rules (only the provided ones) |
+| `create-view <name> --query "<sql>"` | Create a view collection |
+
+#### Options
+
+| Flag | Description |
+|---|---|
+| `--config <path>` | Config file used for fallback URL/token (auth env vars take precedence) |
+| `--out <file>` | Output path for `pull` (default `pb-schema.json`) |
+| `--delete-missing` | For `apply`, remove collections absent from the file (default off) |
+| `--query <sql>` | View query for `create-view` |
+| `--list/--view/--create/--update/--delete <rule>` | Rules for `set-rule` |
+
+`apply` is non-destructive by default (`deleteMissing: false`). Partial
+operations (`add-field`, `add-index`, `set-rule`) fetch the current collection
+and patch it, so they never clobber unrelated fields, indexes, or rules. For
+`set-rule`, a rule value of `"null"` makes the rule superuser-only and `""`
+makes it public.
+
+#### Authentication
+
+Schema commands authenticate as a superuser
+(`_superusers/auth-with-password`). Credentials are read from the environment
+(preferred), falling back to the `pbkit.config.ts` API input — never inline.
+
+| Variable | Purpose |
+|---|---|
+| `POCKETBASE_URL` | PocketBase base URL |
+| `POCKETBASE_ADMIN_EMAIL` | Superuser email (used with the password) |
+| `POCKETBASE_ADMIN_PASSWORD` | Superuser password |
+| `POCKETBASE_ADMIN_TOKEN` | Pre-issued admin token (alternative to email/password) |
+
 ### Config auto-detection
 
 pbkit searches for a config file in the current working directory in this order:

--- a/packages/pbkit/README.md
+++ b/packages/pbkit/README.md
@@ -53,6 +53,46 @@ bunx pbkit generate
 This writes generated files to your configured output directory. Generated files
 use the `.gen.ts` suffix and should not be edited by hand.
 
+## Manage Schema
+
+The `pbkit schema` subcommand manages collection definitions directly against
+the PocketBase admin API, so schema changes don't require hand-rolled `curl`
+calls. It is schema-only — record CRUD is intentionally out of scope.
+
+```bash
+pbkit schema list                       # list all collections (name + type)
+pbkit schema get posts                  # dump one collection as JSON
+pbkit schema pull --out pb-schema.json  # download the full snapshot the generator reads
+pbkit schema apply pb-schema.json       # import definitions (non-destructive)
+pbkit schema add-field posts '{"name":"slug","type":"text"}'
+pbkit schema add-index posts "CREATE UNIQUE INDEX idx_slug ON posts (slug)"
+pbkit schema set-rule posts --list "@request.auth.id != ''" --create "@request.auth.id != ''"
+pbkit schema create-view active_users --query "SELECT id FROM users WHERE verified = true"
+```
+
+`pull` produces exactly the shape `pbkit generate` consumes, so you can pull a
+snapshot and generate types off it. `apply` uses `deleteMissing: false` by
+default — pass `--delete-missing` to remove collections absent from the file.
+Partial operations (`add-field`, `add-index`, `set-rule`) fetch the current
+collection and patch it, so they never clobber unrelated fields, indexes, or
+rules.
+
+For `set-rule`, a rule value of `"null"` makes the rule superuser-only and `""`
+makes it public.
+
+### Authentication
+
+Schema commands authenticate as a superuser. Credentials are read from the
+environment (preferred) and fall back to your `pbkit.config.ts` API input —
+they are never passed inline:
+
+| Variable                     | Purpose                                            |
+| ---------------------------- | -------------------------------------------------- |
+| `POCKETBASE_URL`             | PocketBase base URL                                |
+| `POCKETBASE_ADMIN_EMAIL`     | Superuser email (used with the password)           |
+| `POCKETBASE_ADMIN_PASSWORD`  | Superuser password                                 |
+| `POCKETBASE_ADMIN_TOKEN`     | Pre-issued admin token (alternative to email/pass) |
+
 ## Use The SDK
 
 ```ts

--- a/packages/pbkit/src/cli/index.ts
+++ b/packages/pbkit/src/cli/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { resolveConfigPath } from "../config/loader"
 import { generateProject } from "../generate"
+import { runSchema } from "./schema"
 import type { PbkitConfig } from "../config/types"
 
 function printHelp() {
@@ -8,12 +9,15 @@ function printHelp() {
 
 Usage:
   pbkit generate [--config <path>] [--watch]
+  pbkit schema <subcommand> [...]
   pbkit --help
 
 Options:
   --config, -c    Path to pbkit.config.ts
   --watch, -w     Watch for changes (API polling or file watching)
   --help, -h      Show this help message
+
+Run 'pbkit schema --help' for schema management commands.
 `)
 }
 
@@ -75,6 +79,12 @@ async function runWatch(config: PbkitConfig) {
 
 async function main() {
   const args = process.argv.slice(2)
+
+  if (args[0] === "schema") {
+    await runSchema(args.slice(1))
+    return
+  }
+
   const { config: configPath, watch, help } = parseArgs(args)
 
   if (help) {

--- a/packages/pbkit/src/cli/schema.ts
+++ b/packages/pbkit/src/cli/schema.ts
@@ -48,8 +48,13 @@ async function loadConfigOptional(configPath?: string): Promise<PbkitConfig | un
   }
 }
 
-/** Extract `--flag value` pairs and the leading positional args. */
-function splitArgs(args: string[]): {
+/** Recognize `--long` and single-char `-x` flags (not negative-looking values). */
+function isFlag(arg: string): boolean {
+  return arg.startsWith("--") || (arg.startsWith("-") && arg.length === 2)
+}
+
+/** Extract `--flag value` / `-f value` pairs and the leading positional args. */
+export function splitArgs(args: string[]): {
   positionals: string[]
   flags: Map<string, string | true>
 } {
@@ -57,10 +62,10 @@ function splitArgs(args: string[]): {
   const flags = new Map<string, string | true>()
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
-    if (arg.startsWith("--")) {
-      const key = arg.slice(2)
+    if (isFlag(arg)) {
+      const key = arg.startsWith("--") ? arg.slice(2) : arg.slice(1)
       const next = args[i + 1]
-      if (next === undefined || next.startsWith("--")) {
+      if (next === undefined || isFlag(next)) {
         flags.set(key, true)
       } else {
         flags.set(key, next)

--- a/packages/pbkit/src/cli/schema.ts
+++ b/packages/pbkit/src/cli/schema.ts
@@ -1,0 +1,163 @@
+import { resolveConfigPath } from "../config/loader"
+import { createSchemaClient } from "../schema/client"
+import {
+  addFieldCommand,
+  addIndexCommand,
+  applyCommand,
+  createViewCommand,
+  getCommand,
+  listCommand,
+  pullCommand,
+  RULE_FIELDS,
+  setRuleCommand,
+  type RuleName,
+} from "../schema/commands"
+import type { PbkitConfig } from "../config/types"
+
+const SCHEMA_HELP = `pbkit schema — manage PocketBase collections via the admin API
+
+Usage:
+  pbkit schema list
+  pbkit schema get <collection>
+  pbkit schema pull [--out pb-schema.json]
+  pbkit schema apply <file.json> [--delete-missing]
+  pbkit schema add-field <collection> <json>
+  pbkit schema add-index <collection> "<sql>"
+  pbkit schema set-rule <collection> [--list <rule>] [--view <rule>] [--create <rule>] [--update <rule>] [--delete <rule>]
+  pbkit schema create-view <name> --query "<sql>"
+
+Auth (env vars take precedence over pbkit.config.ts):
+  POCKETBASE_URL              PocketBase base URL
+  POCKETBASE_ADMIN_EMAIL      Superuser email (with password)
+  POCKETBASE_ADMIN_PASSWORD   Superuser password
+  POCKETBASE_ADMIN_TOKEN      Pre-issued admin token (alternative to email/password)
+
+Options:
+  --config, -c   Path to pbkit.config.ts (used for fallback URL/token)
+
+Notes:
+  A rule value of "null" makes the rule superuser-only; "" makes it public.
+`
+
+/** Pull config for URL/token fallback. Missing/invalid config is non-fatal. */
+async function loadConfigOptional(configPath?: string): Promise<PbkitConfig | undefined> {
+  try {
+    return await resolveConfigPath(configPath)
+  } catch {
+    return undefined
+  }
+}
+
+/** Extract `--flag value` pairs and the leading positional args. */
+function splitArgs(args: string[]): {
+  positionals: string[]
+  flags: Map<string, string | true>
+} {
+  const positionals: string[] = []
+  const flags = new Map<string, string | true>()
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2)
+      const next = args[i + 1]
+      if (next === undefined || next.startsWith("--")) {
+        flags.set(key, true)
+      } else {
+        flags.set(key, next)
+        i++
+      }
+    } else {
+      positionals.push(arg)
+    }
+  }
+  return { positionals, flags }
+}
+
+export async function runSchema(args: string[]): Promise<void> {
+  const sub = args[0]
+  if (!sub || sub === "--help" || sub === "-h") {
+    console.log(SCHEMA_HELP)
+    return
+  }
+
+  const KNOWN = new Set([
+    "list", "get", "pull", "apply",
+    "add-field", "add-index", "set-rule", "create-view",
+  ])
+  if (!KNOWN.has(sub)) {
+    throw new Error(`Unknown schema subcommand: ${sub}\nRun 'pbkit schema --help' for usage.`)
+  }
+
+  const rest = args.slice(1)
+  const { positionals, flags } = splitArgs(rest)
+  const configPath =
+    (flags.get("config") as string | undefined) ??
+    (flags.get("c") as string | undefined)
+  const config = await loadConfigOptional(configPath)
+  const client = await createSchemaClient(config)
+
+  switch (sub) {
+    case "list":
+      await listCommand(client)
+      return
+    case "get": {
+      const [collection] = positionals
+      if (!collection) throw new Error("Usage: pbkit schema get <collection>")
+      await getCommand(client, collection)
+      return
+    }
+    case "pull": {
+      const out = flags.get("out")
+      await pullCommand(client, typeof out === "string" ? out : undefined)
+      return
+    }
+    case "apply": {
+      const [file] = positionals
+      if (!file) throw new Error("Usage: pbkit schema apply <file.json>")
+      await applyCommand(client, file, flags.get("delete-missing") === true)
+      return
+    }
+    case "add-field": {
+      const [collection, json] = positionals
+      if (!collection || !json) {
+        throw new Error("Usage: pbkit schema add-field <collection> <json>")
+      }
+      await addFieldCommand(client, collection, json)
+      return
+    }
+    case "add-index": {
+      const [collection, sql] = positionals
+      if (!collection || !sql) {
+        throw new Error('Usage: pbkit schema add-index <collection> "<sql>"')
+      }
+      await addIndexCommand(client, collection, sql)
+      return
+    }
+    case "set-rule": {
+      const [collection] = positionals
+      if (!collection) {
+        throw new Error("Usage: pbkit schema set-rule <collection> --list <rule> ...")
+      }
+      const rules: Partial<Record<RuleName, string | null>> = {}
+      for (const name of Object.keys(RULE_FIELDS) as RuleName[]) {
+        const value = flags.get(name)
+        if (value === undefined) continue
+        // `--list` with no value, or `--list null`, means superuser-only.
+        rules[name] = value === true || value === "null" ? null : value
+      }
+      await setRuleCommand(client, collection, rules)
+      return
+    }
+    case "create-view": {
+      const [name] = positionals
+      const query = flags.get("query")
+      if (!name || typeof query !== "string") {
+        throw new Error('Usage: pbkit schema create-view <name> --query "<sql>"')
+      }
+      await createViewCommand(client, name, query)
+      return
+    }
+    default:
+      throw new Error(`Unknown schema subcommand: ${sub}`)
+  }
+}

--- a/packages/pbkit/src/schema/client.ts
+++ b/packages/pbkit/src/schema/client.ts
@@ -1,0 +1,201 @@
+import type { PbkitConfig } from "../config/types"
+
+export type FetchLike = typeof fetch
+
+export interface RawCollection extends Record<string, unknown> {
+  id: string
+  name: string
+  type: string
+}
+
+export interface SchemaClientOptions {
+  baseUrl: string
+  token: string
+  fetch?: FetchLike
+}
+
+/**
+ * Thin REST client over PocketBase's `/api/collections` admin API.
+ *
+ * Only schema operations are exposed — record CRUD is intentionally out of
+ * scope (mutating prod records is not what this command is for).
+ */
+export class SchemaClient {
+  private readonly baseUrl: string
+  private readonly token: string
+  private readonly fetchImpl: FetchLike
+
+  constructor(options: SchemaClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "")
+    this.token = options.token
+    this.fetchImpl = options.fetch ?? fetch
+  }
+
+  private async request<T>(
+    path: string,
+    init: RequestInit = {},
+  ): Promise<T> {
+    const res = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: this.token,
+        ...(init.headers as Record<string, string> | undefined),
+      },
+    })
+
+    if (!res.ok) {
+      let detail = ""
+      try {
+        detail = await res.text()
+      } catch {
+        // ignore body read failures
+      }
+      throw new Error(
+        `PocketBase API error: ${res.status} ${res.statusText}${detail ? ` — ${detail}` : ""}`,
+      )
+    }
+
+    if (res.status === 204) return undefined as T
+    return (await res.json()) as T
+  }
+
+  /** List every collection (paginated). */
+  async listCollections(): Promise<RawCollection[]> {
+    const all: RawCollection[] = []
+    let page = 1
+    while (true) {
+      const data = await this.request<{
+        items: RawCollection[]
+        totalItems: number
+      }>(`/api/collections?page=${page}&perPage=500`)
+      all.push(...data.items)
+      if (all.length >= data.totalItems || data.items.length === 0) break
+      page++
+    }
+    return all
+  }
+
+  /** Fetch a single collection by id or name. */
+  getCollection(idOrName: string): Promise<RawCollection> {
+    return this.request<RawCollection>(
+      `/api/collections/${encodeURIComponent(idOrName)}`,
+    )
+  }
+
+  /** Partially update a collection. PocketBase replaces array fields wholesale. */
+  updateCollection(
+    idOrName: string,
+    patch: Record<string, unknown>,
+  ): Promise<RawCollection> {
+    return this.request<RawCollection>(
+      `/api/collections/${encodeURIComponent(idOrName)}`,
+      { method: "PATCH", body: JSON.stringify(patch) },
+    )
+  }
+
+  /** Create a new collection. */
+  createCollection(body: Record<string, unknown>): Promise<RawCollection> {
+    return this.request<RawCollection>("/api/collections", {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  }
+
+  /** Import collection definitions. Non-destructive unless `deleteMissing`. */
+  async importCollections(
+    collections: RawCollection[],
+    deleteMissing = false,
+  ): Promise<void> {
+    await this.request<unknown>("/api/collections/import", {
+      method: "PUT",
+      body: JSON.stringify({ collections, deleteMissing }),
+    })
+  }
+}
+
+interface ResolvedAuth {
+  baseUrl: string
+  email?: string
+  password?: string
+  token?: string
+}
+
+/**
+ * Resolve superuser credentials from env vars first, falling back to the
+ * pbkit config's API input. Credentials are never read from anywhere inline.
+ */
+export function resolveAuthSettings(config?: PbkitConfig): ResolvedAuth {
+  let configUrl: string | undefined
+  let configToken: string | undefined
+  const input = config?.input
+  if (typeof input === "string") {
+    if (/^https?:\/\//.test(input)) configUrl = input
+  } else if (input) {
+    configUrl = input.url
+    configToken = input.token
+  }
+
+  const baseUrl = process.env.POCKETBASE_URL ?? configUrl
+  if (!baseUrl) {
+    throw new Error(
+      "No PocketBase URL found. Set POCKETBASE_URL or configure an API `input.url` in pbkit.config.ts.",
+    )
+  }
+
+  return {
+    baseUrl,
+    email: process.env.POCKETBASE_ADMIN_EMAIL,
+    password: process.env.POCKETBASE_ADMIN_PASSWORD,
+    token: process.env.POCKETBASE_ADMIN_TOKEN ?? configToken,
+  }
+}
+
+/** Authenticate as a superuser and return a bearer token. */
+export async function superuserAuth(
+  baseUrl: string,
+  identity: string,
+  password: string,
+  fetchImpl: FetchLike = fetch,
+): Promise<string> {
+  const res = await fetchImpl(
+    `${baseUrl.replace(/\/+$/, "")}/api/collections/_superusers/auth-with-password`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ identity, password }),
+    },
+  )
+  if (!res.ok) {
+    throw new Error(
+      `Superuser auth failed: ${res.status} ${res.statusText}. Check POCKETBASE_ADMIN_EMAIL / POCKETBASE_ADMIN_PASSWORD.`,
+    )
+  }
+  const data = (await res.json()) as { token?: string }
+  if (!data.token) throw new Error("Superuser auth returned no token.")
+  return data.token
+}
+
+/**
+ * Build an authenticated SchemaClient. Prefers email/password superuser auth;
+ * falls back to a pre-issued token. Throws if neither is available.
+ */
+export async function createSchemaClient(
+  config?: PbkitConfig,
+  fetchImpl: FetchLike = fetch,
+): Promise<SchemaClient> {
+  const auth = resolveAuthSettings(config)
+
+  let token = auth.token
+  if (auth.email && auth.password) {
+    token = await superuserAuth(auth.baseUrl, auth.email, auth.password, fetchImpl)
+  }
+
+  if (!token) {
+    throw new Error(
+      "No superuser credentials found. Set POCKETBASE_ADMIN_EMAIL and POCKETBASE_ADMIN_PASSWORD, or POCKETBASE_ADMIN_TOKEN.",
+    )
+  }
+
+  return new SchemaClient({ baseUrl: auth.baseUrl, token, fetch: fetchImpl })
+}

--- a/packages/pbkit/src/schema/client.ts
+++ b/packages/pbkit/src/schema/client.ts
@@ -186,6 +186,17 @@ export async function createSchemaClient(
 ): Promise<SchemaClient> {
   const auth = resolveAuthSettings(config)
 
+  if (auth.email && !auth.password) {
+    throw new Error(
+      "POCKETBASE_ADMIN_EMAIL is set but POCKETBASE_ADMIN_PASSWORD is missing — both are required for email/password auth.",
+    )
+  }
+  if (!auth.email && auth.password) {
+    throw new Error(
+      "POCKETBASE_ADMIN_PASSWORD is set but POCKETBASE_ADMIN_EMAIL is missing — both are required for email/password auth.",
+    )
+  }
+
   let token = auth.token
   if (auth.email && auth.password) {
     token = await superuserAuth(auth.baseUrl, auth.email, auth.password, fetchImpl)

--- a/packages/pbkit/src/schema/commands.ts
+++ b/packages/pbkit/src/schema/commands.ts
@@ -1,0 +1,159 @@
+import { readFileSync, writeFileSync } from "fs"
+import { resolve } from "path"
+import type { RawCollection, SchemaClient } from "./client"
+
+export const RULE_FIELDS = {
+  list: "listRule",
+  view: "viewRule",
+  create: "createRule",
+  update: "updateRule",
+  delete: "deleteRule",
+} as const
+
+export type RuleName = keyof typeof RULE_FIELDS
+
+/** `schema list` — print every collection's name and type. */
+export async function listCommand(client: SchemaClient): Promise<void> {
+  const collections = await client.listCollections()
+  const sorted = [...collections].sort((a, b) => a.name.localeCompare(b.name))
+  for (const c of sorted) {
+    console.log(`${c.name}  (${c.type})`)
+  }
+  console.log(`\n${sorted.length} collection(s)`)
+}
+
+/** `schema get <collection>` — dump a single collection as JSON. */
+export async function getCommand(
+  client: SchemaClient,
+  collection: string,
+): Promise<void> {
+  const data = await client.getCollection(collection)
+  console.log(JSON.stringify(data, null, 2))
+}
+
+/** `schema pull [--out file]` — write the full schema snapshot to disk. */
+export async function pullCommand(
+  client: SchemaClient,
+  outPath = "pb-schema.json",
+): Promise<void> {
+  const collections = await client.listCollections()
+  const target = resolve(process.cwd(), outPath)
+  writeFileSync(target, JSON.stringify(collections, null, 2) + "\n")
+  console.log(`Wrote ${collections.length} collection(s) to ${outPath}`)
+}
+
+/** `schema apply <file>` — import collection definitions (non-destructive). */
+export async function applyCommand(
+  client: SchemaClient,
+  filePath: string,
+  deleteMissing = false,
+): Promise<void> {
+  const raw = readFileSync(resolve(process.cwd(), filePath), "utf-8")
+  const parsed: unknown = JSON.parse(raw)
+  const collections = Array.isArray(parsed)
+    ? (parsed as RawCollection[])
+    : (parsed as { collections?: RawCollection[] }).collections
+  if (!Array.isArray(collections)) {
+    throw new Error(
+      `${filePath} must be an array of collections or { collections: [...] }`,
+    )
+  }
+  await client.importCollections(collections, deleteMissing)
+  console.log(
+    `Applied ${collections.length} collection(s)${deleteMissing ? " (deleteMissing: true)" : ""}`,
+  )
+}
+
+/**
+ * `schema add-field <collection> <json>` — append a field, preserving the
+ * rest of the `fields` array (PocketBase replaces the array wholesale on PATCH).
+ */
+export async function addFieldCommand(
+  client: SchemaClient,
+  collection: string,
+  fieldJson: string,
+): Promise<RawCollection> {
+  let field: Record<string, unknown>
+  try {
+    field = JSON.parse(fieldJson)
+  } catch {
+    throw new Error("add-field expects a valid JSON field definition")
+  }
+  const current = await client.getCollection(collection)
+  const fields = Array.isArray(current.fields)
+    ? (current.fields as Record<string, unknown>[])
+    : []
+  if (field.name && fields.some((f) => f.name === field.name)) {
+    throw new Error(
+      `Field "${String(field.name)}" already exists on ${collection}`,
+    )
+  }
+  const updated = await client.updateCollection(collection, {
+    fields: [...fields, field],
+  })
+  console.log(`Added field "${String(field.name)}" to ${collection}`)
+  return updated
+}
+
+/**
+ * `schema add-index <collection> "<sql>"` — append an index, merging with the
+ * existing `indexes` array rather than overwriting it.
+ */
+export async function addIndexCommand(
+  client: SchemaClient,
+  collection: string,
+  sql: string,
+): Promise<RawCollection> {
+  const current = await client.getCollection(collection)
+  const indexes = Array.isArray(current.indexes)
+    ? (current.indexes as string[])
+    : []
+  if (indexes.includes(sql)) {
+    throw new Error(`Index already exists on ${collection}`)
+  }
+  const updated = await client.updateCollection(collection, {
+    indexes: [...indexes, sql],
+  })
+  console.log(`Added index to ${collection}`)
+  return updated
+}
+
+/**
+ * `schema set-rule <collection> --list/--view/...` — update API rules. Only the
+ * provided rules are patched; unrelated rules are untouched.
+ */
+export async function setRuleCommand(
+  client: SchemaClient,
+  collection: string,
+  rules: Partial<Record<RuleName, string | null>>,
+): Promise<RawCollection> {
+  const patch: Record<string, unknown> = {}
+  for (const [name, value] of Object.entries(rules)) {
+    patch[RULE_FIELDS[name as RuleName]] = value
+  }
+  if (Object.keys(patch).length === 0) {
+    throw new Error(
+      "set-rule requires at least one of --list/--view/--create/--update/--delete",
+    )
+  }
+  const updated = await client.updateCollection(collection, patch)
+  console.log(
+    `Updated rule(s) on ${collection}: ${Object.keys(rules).join(", ")}`,
+  )
+  return updated
+}
+
+/** `schema create-view <name> --query "<sql>"` — create a view collection. */
+export async function createViewCommand(
+  client: SchemaClient,
+  name: string,
+  query: string,
+): Promise<RawCollection> {
+  const created = await client.createCollection({
+    name,
+    type: "view",
+    viewQuery: query,
+  })
+  console.log(`Created view collection "${name}"`)
+  return created
+}

--- a/packages/pbkit/src/test/schema-commands.test.ts
+++ b/packages/pbkit/src/test/schema-commands.test.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect } from "bun:test"
+import { SchemaClient, resolveAuthSettings } from "../schema/client"
+import {
+  addFieldCommand,
+  addIndexCommand,
+  setRuleCommand,
+} from "../schema/commands"
+import type { PbkitConfig } from "../config/types"
+
+interface Call {
+  url: string
+  method: string
+  body?: unknown
+}
+
+/** A fetch stub that records calls and returns queued JSON responses. */
+function fakeFetch(handler: (call: Call) => unknown) {
+  const calls: Call[] = []
+  const impl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const call: Call = {
+      url: String(input),
+      method: init?.method ?? "GET",
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+    }
+    calls.push(call)
+    const result = handler(call)
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => result,
+      text: async () => JSON.stringify(result),
+    } as Response
+  }) as typeof fetch
+  return { impl, calls }
+}
+
+describe("add-field", () => {
+  test("appends to existing fields, preserving the rest", async () => {
+    const { impl, calls } = fakeFetch((call) => {
+      if (call.method === "GET") {
+        return {
+          id: "c1",
+          name: "posts",
+          type: "base",
+          fields: [{ name: "title", type: "text" }],
+        }
+      }
+      return { id: "c1", name: "posts", type: "base", fields: call.body }
+    })
+    const client = new SchemaClient({ baseUrl: "http://x", token: "t", fetch: impl })
+
+    await addFieldCommand(client, "posts", JSON.stringify({ name: "body", type: "editor" }))
+
+    const patch = calls.find((c) => c.method === "PATCH")!
+    expect(patch.body).toEqual({
+      fields: [
+        { name: "title", type: "text" },
+        { name: "body", type: "editor" },
+      ],
+    })
+  })
+
+  test("rejects a duplicate field name", async () => {
+    const { impl } = fakeFetch(() => ({
+      id: "c1",
+      name: "posts",
+      type: "base",
+      fields: [{ name: "title", type: "text" }],
+    }))
+    const client = new SchemaClient({ baseUrl: "http://x", token: "t", fetch: impl })
+
+    await expect(
+      addFieldCommand(client, "posts", JSON.stringify({ name: "title", type: "text" })),
+    ).rejects.toThrow("already exists")
+  })
+})
+
+describe("add-index", () => {
+  test("merges with existing indexes rather than overwriting", async () => {
+    const { impl, calls } = fakeFetch((call) => {
+      if (call.method === "GET") {
+        return { id: "c1", name: "posts", type: "base", indexes: ["CREATE INDEX a ON posts (a)"] }
+      }
+      return { id: "c1" }
+    })
+    const client = new SchemaClient({ baseUrl: "http://x", token: "t", fetch: impl })
+
+    await addIndexCommand(client, "posts", "CREATE INDEX b ON posts (b)")
+
+    const patch = calls.find((c) => c.method === "PATCH")!
+    expect(patch.body).toEqual({
+      indexes: ["CREATE INDEX a ON posts (a)", "CREATE INDEX b ON posts (b)"],
+    })
+  })
+})
+
+describe("set-rule", () => {
+  test("patches only the provided rules", async () => {
+    const { impl, calls } = fakeFetch(() => ({ id: "c1" }))
+    const client = new SchemaClient({ baseUrl: "http://x", token: "t", fetch: impl })
+
+    await setRuleCommand(client, "posts", { list: "@request.auth.id != ''", create: null })
+
+    const patch = calls.find((c) => c.method === "PATCH")!
+    expect(patch.body).toEqual({
+      listRule: "@request.auth.id != ''",
+      createRule: null,
+    })
+  })
+
+  test("throws when no rule flags are given", async () => {
+    const { impl } = fakeFetch(() => ({ id: "c1" }))
+    const client = new SchemaClient({ baseUrl: "http://x", token: "t", fetch: impl })
+    await expect(setRuleCommand(client, "posts", {})).rejects.toThrow("at least one")
+  })
+})
+
+describe("resolveAuthSettings", () => {
+  const ENV_KEYS = [
+    "POCKETBASE_URL",
+    "POCKETBASE_ADMIN_EMAIL",
+    "POCKETBASE_ADMIN_PASSWORD",
+    "POCKETBASE_ADMIN_TOKEN",
+  ]
+  function withEnv(env: Record<string, string | undefined>, fn: () => void) {
+    const saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]))
+    for (const k of ENV_KEYS) delete process.env[k]
+    Object.assign(process.env, env)
+    try {
+      fn()
+    } finally {
+      for (const k of ENV_KEYS) delete process.env[k]
+      for (const [k, v] of Object.entries(saved)) if (v !== undefined) process.env[k] = v
+    }
+  }
+
+  test("env vars take precedence over config", () => {
+    const config: PbkitConfig = {
+      input: { url: "http://config-url", token: "config-token" },
+      output: "./gen",
+    }
+    withEnv({ POCKETBASE_URL: "http://env-url", POCKETBASE_ADMIN_TOKEN: "env-token" }, () => {
+      const auth = resolveAuthSettings(config)
+      expect(auth.baseUrl).toBe("http://env-url")
+      expect(auth.token).toBe("env-token")
+    })
+  })
+
+  test("falls back to config input url/token", () => {
+    const config: PbkitConfig = {
+      input: { url: "http://config-url", token: "config-token" },
+      output: "./gen",
+    }
+    withEnv({}, () => {
+      const auth = resolveAuthSettings(config)
+      expect(auth.baseUrl).toBe("http://config-url")
+      expect(auth.token).toBe("config-token")
+    })
+  })
+
+  test("throws when no URL is resolvable", () => {
+    withEnv({}, () => {
+      expect(() => resolveAuthSettings(undefined)).toThrow("No PocketBase URL")
+    })
+  })
+})

--- a/packages/pbkit/src/test/schema-commands.test.ts
+++ b/packages/pbkit/src/test/schema-commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test"
-import { SchemaClient, resolveAuthSettings } from "../schema/client"
+import { SchemaClient, createSchemaClient, resolveAuthSettings } from "../schema/client"
+import { splitArgs } from "../cli/schema"
 import {
   addFieldCommand,
   addIndexCommand,
@@ -163,5 +164,40 @@ describe("resolveAuthSettings", () => {
     withEnv({}, () => {
       expect(() => resolveAuthSettings(undefined)).toThrow("No PocketBase URL")
     })
+  })
+
+  test("rejects a partial email/password pair instead of falling through", async () => {
+    const config: PbkitConfig = { input: { url: "http://x" }, output: "./gen" }
+    await withEnv({ POCKETBASE_ADMIN_EMAIL: "admin@example.com" }, async () => {
+      await expect(createSchemaClient(config)).rejects.toThrow(
+        "POCKETBASE_ADMIN_PASSWORD is missing",
+      )
+    })
+    await withEnv({ POCKETBASE_ADMIN_PASSWORD: "secret" }, async () => {
+      await expect(createSchemaClient(config)).rejects.toThrow(
+        "POCKETBASE_ADMIN_EMAIL is missing",
+      )
+    })
+  })
+})
+
+describe("splitArgs", () => {
+  test("parses single-dash short flags with a value", () => {
+    const { positionals, flags } = splitArgs(["-c", "./my-config.ts"])
+    expect(positionals).toEqual([])
+    expect(flags.get("c")).toBe("./my-config.ts")
+  })
+
+  test("parses long flags and positionals together", () => {
+    const { positionals, flags } = splitArgs(["posts", "--out", "snap.json", "--delete-missing"])
+    expect(positionals).toEqual(["posts"])
+    expect(flags.get("out")).toBe("snap.json")
+    expect(flags.get("delete-missing")).toBe(true)
+  })
+
+  test("treats a following flag as a boolean, not a value", () => {
+    const { flags } = splitArgs(["--delete-missing", "-c", "cfg.ts"])
+    expect(flags.get("delete-missing")).toBe(true)
+    expect(flags.get("c")).toBe("cfg.ts")
   })
 })

--- a/skills/pbkit/SKILL.md
+++ b/skills/pbkit/SKILL.md
@@ -150,6 +150,28 @@ npx pbkit generate -c ./path/to/pbkit.config.ts
 
 Watch mode polls the schema source and regenerates output when it changes.
 
+### Schema management (`pbkit schema`)
+
+`pbkit schema` manages PocketBase collection definitions directly against the admin API (`/api/collections`). It is schema-only — record create/update/delete is intentionally out of scope.
+
+```bash
+pbkit schema list                         # list collections (name + type)
+pbkit schema get posts                    # dump one collection as JSON
+pbkit schema pull --out pb-schema.json    # download the snapshot the generator reads
+pbkit schema apply pb-schema.json         # import definitions (non-destructive)
+pbkit schema add-field posts '{"name":"slug","type":"text"}'
+pbkit schema add-index posts "CREATE UNIQUE INDEX idx_slug ON posts (slug)"
+pbkit schema set-rule posts --list "@request.auth.id != ''" --create "@request.auth.id != ''"
+pbkit schema create-view active_users --query "SELECT id FROM users WHERE verified = true"
+```
+
+Auth is via superuser credentials from the environment (preferred) with config fallback, never inline: `POCKETBASE_URL`, `POCKETBASE_ADMIN_EMAIL`, `POCKETBASE_ADMIN_PASSWORD`, or `POCKETBASE_ADMIN_TOKEN`.
+
+- `pull` produces the same shape `pbkit generate` consumes — snapshot a live instance, then generate off the file.
+- `apply` is non-destructive by default (`deleteMissing: false`); pass `--delete-missing` to mirror the file exactly.
+- `add-field`, `add-index`, and `set-rule` fetch the current collection and patch it, so they never clobber unrelated fields, indexes, or rules.
+- For `set-rule`, a rule value of `"null"` makes the rule superuser-only and `""` makes it public.
+
 ## Client Singleton
 
 pbkit generates a default PocketBase client in `client.gen.ts`:


### PR DESCRIPTION
Closes #59

## What

Adds a `pbkit schema` CLI subcommand that manages PocketBase collection definitions directly against the admin API (`/api/collections`), replacing the ad-hoc `curl` + `python` flow. Schema-only — record CRUD is intentionally out of scope.

```bash
pbkit schema list                       # list collections (name + type)
pbkit schema get <collection>           # dump one collection as JSON
pbkit schema pull [--out pb-schema.json]# download the snapshot the generator reads
pbkit schema apply <file.json>          # import definitions (non-destructive)
pbkit schema add-field <collection> <json>
pbkit schema add-index <collection> "<sql>"
pbkit schema set-rule <collection> --list/--view/--create/--update/--delete <rule>
pbkit schema create-view <name> --query "<sql>"
```

## Auth

Superuser auth via `_superusers/auth-with-password`. Credentials resolve from env (preferred) with config fallback, never inline:
`POCKETBASE_URL`, `POCKETBASE_ADMIN_EMAIL`, `POCKETBASE_ADMIN_PASSWORD`, or `POCKETBASE_ADMIN_TOKEN`.

## Acceptance criteria

- [x] `pull` produces the same shape the generator reads (raw `/api/collections` array → `parseJson`).
- [x] `apply` is idempotent and non-destructive by default (`deleteMissing: false`); opt-in `--delete-missing`.
- [x] Schema-only — no record create/update/delete exposed.
- [x] Partial updates (`add-field`, `add-index`, `set-rule`) fetch current state and patch — never clobber unrelated fields/indexes/rules.
- [x] Docs updated (README, docs site CLI reference + new how-to, and the pbkit skill).

## Notes

- `add-field`/`add-index` send the full merged array because PocketBase replaces array fields wholesale on PATCH.
- For `set-rule`, a value of `"null"` makes a rule superuser-only and `""` makes it public.

## Verification

- `tsc --noEmit` clean
- `bun test` — 138 pass / 0 fail (8 new tests covering merge + auth resolution)
- Astro docs site builds (22 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)