### PR TITLE
refactor(cli): build CLI on citty

### DIFF
--- a/.changeset/cli-citty.md
+++ b/.changeset/cli-citty.md
@@ -1,0 +1,8 @@
+---
+"@karnak19/pbkit": patch
+---
+
+Build the CLI on [citty](https://github.com/unjs/citty). Both `pbkit generate`
+and `pbkit schema` (with its subcommands) now have auto-generated `--help`/usage
+and consistent flag parsing — short flags like `-c` work everywhere. Existing
+`generate` behavior is unchanged.

--- a/bun.lock
+++ b/bun.lock
@@ -33,9 +33,12 @@
     },
     "packages/pbkit": {
       "name": "@karnak19/pbkit",
-      "version": "0.6.0",
+      "version": "1.0.0",
       "bin": {
         "pbkit": "./dist/cli/index.js",
+      },
+      "dependencies": {
+        "citty": "^0.2.2",
       },
       "devDependencies": {
         "@types/bun": "^1.3.13",
@@ -44,27 +47,27 @@
     },
     "packages/pbkit-realtime": {
       "name": "@karnak19/pbkit-realtime",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "devDependencies": {
         "@karnak19/pbkit": "workspace:*",
         "@types/bun": "^1.3.13",
         "typescript": "^6.0.0",
       },
       "peerDependencies": {
-        "@karnak19/pbkit": "^0.6.0",
+        "@karnak19/pbkit": "^1.0.0",
         "pocketbase": ">=0.21.0",
       },
     },
     "packages/pbkit-tanstack": {
       "name": "@karnak19/pbkit-tanstack",
-      "version": "2.0.0",
+      "version": "4.0.0",
       "devDependencies": {
         "@karnak19/pbkit": "workspace:*",
         "@types/bun": "^1.3.13",
         "typescript": "^6.0.0",
       },
       "peerDependencies": {
-        "@karnak19/pbkit": "^0.6.0",
+        "@karnak19/pbkit": "^1.0.0",
         "@tanstack/angular-query-experimental": "^5.0.0",
         "@tanstack/react-query": "^5.0.0",
         "@tanstack/solid-query": "^5.0.0",
@@ -81,7 +84,7 @@
     },
     "packages/pbkit-zod": {
       "name": "@karnak19/pbkit-zod",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "devDependencies": {
         "@karnak19/pbkit": "workspace:*",
         "@types/bun": "^1.3.13",
@@ -89,7 +92,7 @@
         "zod": "^3.25.0",
       },
       "peerDependencies": {
-        "@karnak19/pbkit": "^0.6.0",
+        "@karnak19/pbkit": "^1.0.0",
         "zod": "^3.0.0",
       },
     },
@@ -490,6 +493,8 @@
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 

--- a/packages/pbkit/package.json
+++ b/packages/pbkit/package.json
@@ -42,5 +42,8 @@
   "devDependencies": {
     "@types/bun": "^1.3.13",
     "typescript": "^6.0.0"
+  },
+  "dependencies": {
+    "citty": "^0.2.2"
   }
 }

--- a/packages/pbkit/src/cli/action.ts
+++ b/packages/pbkit/src/cli/action.ts
@@ -1,0 +1,18 @@
+import type { ArgsDef, CommandContext } from "citty"
+
+/**
+ * Wrap a command's `run` so expected errors (auth, config, API failures) print
+ * a clean one-line message and exit, instead of citty's full stack dump.
+ */
+export function action<T extends ArgsDef>(
+  fn: (ctx: CommandContext<T>) => Promise<void>,
+): (ctx: CommandContext<T>) => Promise<void> {
+  return async (ctx) => {
+    try {
+      await fn(ctx)
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : err)
+      process.exit(1)
+    }
+  }
+}

--- a/packages/pbkit/src/cli/index.ts
+++ b/packages/pbkit/src/cli/index.ts
@@ -1,49 +1,10 @@
 #!/usr/bin/env bun
+import { defineCommand, runMain } from "citty"
+import { action } from "./action"
 import { resolveConfigPath } from "../config/loader"
 import { generateProject } from "../generate"
-import { runSchema } from "./schema"
+import { schemaCommand } from "./schema"
 import type { PbkitConfig } from "../config/types"
-
-function printHelp() {
-  console.log(`pbkit — PocketBase code generation toolkit
-
-Usage:
-  pbkit generate [--config <path>] [--watch]
-  pbkit schema <subcommand> [...]
-  pbkit --help
-
-Options:
-  --config, -c    Path to pbkit.config.ts
-  --watch, -w     Watch for changes (API polling or file watching)
-  --help, -h      Show this help message
-
-Run 'pbkit schema --help' for schema management commands.
-`)
-}
-
-function parseArgs(args: string[]): { config?: string; watch: boolean; help: boolean } {
-  let config: string | undefined
-  let watch = false
-  let help = false
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i]
-    if (arg === "--help" || arg === "-h") {
-      help = true
-    } else if (arg === "--config" || arg === "-c") {
-      config = args[++i]
-    } else if (arg === "--watch" || arg === "-w") {
-      watch = true
-    } else if (arg === "generate") {
-      // default command
-    } else {
-      console.error(`Unknown argument: ${arg}`)
-      process.exit(1)
-    }
-  }
-
-  return { config, watch, help }
-}
 
 async function runGenerate(config: PbkitConfig) {
   const result = await generateProject(config)
@@ -77,31 +38,32 @@ async function runWatch(config: PbkitConfig) {
   setInterval(regenerate, 10_000)
 }
 
-async function main() {
-  const args = process.argv.slice(2)
+const generateArgs = {
+  config: { type: "string", alias: "c", description: "Path to pbkit.config.ts" },
+  watch: { type: "boolean", alias: "w", description: "Watch for changes and regenerate" },
+} as const
 
-  if (args[0] === "schema") {
-    await runSchema(args.slice(1))
-    return
-  }
-
-  const { config: configPath, watch, help } = parseArgs(args)
-
-  if (help) {
-    printHelp()
-    process.exit(0)
-  }
-
-  const config = await resolveConfigPath(configPath)
-
-  if (watch) {
+async function doGenerate(args: { config?: string; watch?: boolean }) {
+  const config = await resolveConfigPath(args.config)
+  if (args.watch) {
     await runWatch(config)
   } else {
     await runGenerate(config)
   }
 }
 
-main().catch((err) => {
-  console.error(err instanceof Error ? err.message : err)
-  process.exit(1)
+const generate = defineCommand({
+  meta: { name: "generate", description: "Generate types and SDK from your pbkit.config.ts" },
+  args: { ...generateArgs },
+  run: action(({ args }) => doGenerate(args)),
 })
+
+const main = defineCommand({
+  meta: { name: "pbkit", description: "PocketBase code generation toolkit" },
+  args: { ...generateArgs },
+  subCommands: { generate, schema: schemaCommand },
+  // Bare `pbkit` (with optional flags) runs generate.
+  run: action(({ args }) => doGenerate(args)),
+})
+
+runMain(main)

--- a/packages/pbkit/src/cli/schema.ts
+++ b/packages/pbkit/src/cli/schema.ts
@@ -1,5 +1,7 @@
+import { defineCommand } from "citty"
+import { action } from "./action"
 import { resolveConfigPath } from "../config/loader"
-import { createSchemaClient } from "../schema/client"
+import { createSchemaClient, type SchemaClient } from "../schema/client"
 import {
   addFieldCommand,
   addIndexCommand,
@@ -8,38 +10,12 @@ import {
   getCommand,
   listCommand,
   pullCommand,
-  RULE_FIELDS,
   setRuleCommand,
   type RuleName,
 } from "../schema/commands"
 import type { PbkitConfig } from "../config/types"
 
-const SCHEMA_HELP = `pbkit schema — manage PocketBase collections via the admin API
-
-Usage:
-  pbkit schema list
-  pbkit schema get <collection>
-  pbkit schema pull [--out pb-schema.json]
-  pbkit schema apply <file.json> [--delete-missing]
-  pbkit schema add-field <collection> <json>
-  pbkit schema add-index <collection> "<sql>"
-  pbkit schema set-rule <collection> [--list <rule>] [--view <rule>] [--create <rule>] [--update <rule>] [--delete <rule>]
-  pbkit schema create-view <name> --query "<sql>"
-
-Auth (env vars take precedence over pbkit.config.ts):
-  POCKETBASE_URL              PocketBase base URL
-  POCKETBASE_ADMIN_EMAIL      Superuser email (with password)
-  POCKETBASE_ADMIN_PASSWORD   Superuser password
-  POCKETBASE_ADMIN_TOKEN      Pre-issued admin token (alternative to email/password)
-
-Options:
-  --config, -c   Path to pbkit.config.ts (used for fallback URL/token)
-
-Notes:
-  A rule value of "null" makes the rule superuser-only; "" makes it public.
-`
-
-/** Pull config for URL/token fallback. Missing/invalid config is non-fatal. */
+/** Config is only a fallback for URL/token here, so missing/invalid is non-fatal. */
 async function loadConfigOptional(configPath?: string): Promise<PbkitConfig | undefined> {
   try {
     return await resolveConfigPath(configPath)
@@ -48,121 +24,136 @@ async function loadConfigOptional(configPath?: string): Promise<PbkitConfig | un
   }
 }
 
-/** Recognize `--long` and single-char `-x` flags (not negative-looking values). */
-function isFlag(arg: string): boolean {
-  return arg.startsWith("--") || (arg.startsWith("-") && arg.length === 2)
+const configArg = {
+  config: {
+    type: "string",
+    alias: "c",
+    description: "Path to pbkit.config.ts (fallback URL/token; env vars take precedence)",
+  },
+} as const
+
+async function client(configPath?: string): Promise<SchemaClient> {
+  return createSchemaClient(await loadConfigOptional(configPath))
 }
 
-/** Extract `--flag value` / `-f value` pairs and the leading positional args. */
-export function splitArgs(args: string[]): {
-  positionals: string[]
-  flags: Map<string, string | true>
-} {
-  const positionals: string[] = []
-  const flags = new Map<string, string | true>()
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i]
-    if (isFlag(arg)) {
-      const key = arg.startsWith("--") ? arg.slice(2) : arg.slice(1)
-      const next = args[i + 1]
-      if (next === undefined || isFlag(next)) {
-        flags.set(key, true)
-      } else {
-        flags.set(key, next)
-        i++
-      }
-    } else {
-      positionals.push(arg)
-    }
-  }
-  return { positionals, flags }
-}
+const list = defineCommand({
+  meta: { name: "list", description: "List all collections (name + type)" },
+  args: { ...configArg },
+  run: action(async ({ args }) => {
+    await listCommand(await client(args.config))
+  }),
+})
 
-export async function runSchema(args: string[]): Promise<void> {
-  const sub = args[0]
-  if (!sub || sub === "--help" || sub === "-h") {
-    console.log(SCHEMA_HELP)
-    return
-  }
+const get = defineCommand({
+  meta: { name: "get", description: "Dump one collection as JSON" },
+  args: {
+    collection: { type: "positional", required: true, description: "Collection name or id" },
+    ...configArg,
+  },
+  run: action(async ({ args }) => {
+    await getCommand(await client(args.config), args.collection)
+  }),
+})
 
-  const KNOWN = new Set([
-    "list", "get", "pull", "apply",
-    "add-field", "add-index", "set-rule", "create-view",
-  ])
-  if (!KNOWN.has(sub)) {
-    throw new Error(`Unknown schema subcommand: ${sub}\nRun 'pbkit schema --help' for usage.`)
-  }
+const pull = defineCommand({
+  meta: { name: "pull", description: "Download the full schema snapshot the generator reads" },
+  args: {
+    out: { type: "string", default: "pb-schema.json", description: "Output file" },
+    ...configArg,
+  },
+  run: action(async ({ args }) => {
+    await pullCommand(await client(args.config), args.out)
+  }),
+})
 
-  const rest = args.slice(1)
-  const { positionals, flags } = splitArgs(rest)
-  const configPath =
-    (flags.get("config") as string | undefined) ??
-    (flags.get("c") as string | undefined)
-  const config = await loadConfigOptional(configPath)
-  const client = await createSchemaClient(config)
+const apply = defineCommand({
+  meta: { name: "apply", description: "Import collection definitions (non-destructive by default)" },
+  args: {
+    file: { type: "positional", required: true, description: "Schema JSON file" },
+    "delete-missing": {
+      type: "boolean",
+      description: "Remove collections absent from the file",
+    },
+    ...configArg,
+  },
+  run: action(async ({ args }) => {
+    await applyCommand(await client(args.config), args.file, args["delete-missing"] === true)
+  }),
+})
 
-  switch (sub) {
-    case "list":
-      await listCommand(client)
-      return
-    case "get": {
-      const [collection] = positionals
-      if (!collection) throw new Error("Usage: pbkit schema get <collection>")
-      await getCommand(client, collection)
-      return
+const addField = defineCommand({
+  meta: { name: "add-field", description: "Append a field, preserving the existing fields array" },
+  args: {
+    collection: { type: "positional", required: true, description: "Collection name or id" },
+    field: { type: "positional", required: true, description: "Field definition as JSON" },
+    ...configArg,
+  },
+  run: action(async ({ args }) => {
+    await addFieldCommand(await client(args.config), args.collection, args.field)
+  }),
+})
+
+const addIndex = defineCommand({
+  meta: { name: "add-index", description: "Append an index, merging with existing indexes" },
+  args: {
+    collection: { type: "positional", required: true, description: "Collection name or id" },
+    sql: { type: "positional", required: true, description: "CREATE INDEX statement" },
+    ...configArg,
+  },
+  run: action(async ({ args }) => {
+    await addIndexCommand(await client(args.config), args.collection, args.sql)
+  }),
+})
+
+const setRule = defineCommand({
+  meta: { name: "set-rule", description: "Update API rules (only the provided ones)" },
+  args: {
+    collection: { type: "positional", required: true, description: "Collection name or id" },
+    list: { type: "string", description: "listRule" },
+    view: { type: "string", description: "viewRule" },
+    create: { type: "string", description: "createRule" },
+    update: { type: "string", description: "updateRule" },
+    delete: { type: "string", description: "deleteRule" },
+    ...configArg,
+  },
+  run: action(async ({ args }) => {
+    const rules: Partial<Record<RuleName, string | null>> = {}
+    for (const name of ["list", "view", "create", "update", "delete"] as RuleName[]) {
+      const value = args[name]
+      if (value === undefined) continue
+      // `"null"` makes the rule superuser-only; "" makes it public.
+      rules[name] = value === "null" ? null : value
     }
-    case "pull": {
-      const out = flags.get("out")
-      await pullCommand(client, typeof out === "string" ? out : undefined)
-      return
-    }
-    case "apply": {
-      const [file] = positionals
-      if (!file) throw new Error("Usage: pbkit schema apply <file.json>")
-      await applyCommand(client, file, flags.get("delete-missing") === true)
-      return
-    }
-    case "add-field": {
-      const [collection, json] = positionals
-      if (!collection || !json) {
-        throw new Error("Usage: pbkit schema add-field <collection> <json>")
-      }
-      await addFieldCommand(client, collection, json)
-      return
-    }
-    case "add-index": {
-      const [collection, sql] = positionals
-      if (!collection || !sql) {
-        throw new Error('Usage: pbkit schema add-index <collection> "<sql>"')
-      }
-      await addIndexCommand(client, collection, sql)
-      return
-    }
-    case "set-rule": {
-      const [collection] = positionals
-      if (!collection) {
-        throw new Error("Usage: pbkit schema set-rule <collection> --list <rule> ...")
-      }
-      const rules: Partial<Record<RuleName, string | null>> = {}
-      for (const name of Object.keys(RULE_FIELDS) as RuleName[]) {
-        const value = flags.get(name)
-        if (value === undefined) continue
-        // `--list` with no value, or `--list null`, means superuser-only.
-        rules[name] = value === true || value === "null" ? null : value
-      }
-      await setRuleCommand(client, collection, rules)
-      return
-    }
-    case "create-view": {
-      const [name] = positionals
-      const query = flags.get("query")
-      if (!name || typeof query !== "string") {
-        throw new Error('Usage: pbkit schema create-view <name> --query "<sql>"')
-      }
-      await createViewCommand(client, name, query)
-      return
-    }
-    default:
-      throw new Error(`Unknown schema subcommand: ${sub}`)
-  }
-}
+    await setRuleCommand(await client(args.config), args.collection, rules)
+  }),
+})
+
+const createView = defineCommand({
+  meta: { name: "create-view", description: "Create a view collection" },
+  args: {
+    name: { type: "positional", required: true, description: "View collection name" },
+    query: { type: "string", required: true, description: "View SQL query" },
+    ...configArg,
+  },
+  run: action(async ({ args }) => {
+    await createViewCommand(await client(args.config), args.name, args.query)
+  }),
+})
+
+export const schemaCommand = defineCommand({
+  meta: {
+    name: "schema",
+    description:
+      "Manage PocketBase collections via the admin API. Auth from POCKETBASE_URL / POCKETBASE_ADMIN_EMAIL / POCKETBASE_ADMIN_PASSWORD (or POCKETBASE_ADMIN_TOKEN).",
+  },
+  subCommands: {
+    list,
+    get,
+    pull,
+    apply,
+    "add-field": addField,
+    "add-index": addIndex,
+    "set-rule": setRule,
+    "create-view": createView,
+  },
+})

--- a/packages/pbkit/src/test/schema-commands.test.ts
+++ b/packages/pbkit/src/test/schema-commands.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect } from "bun:test"
 import { SchemaClient, createSchemaClient, resolveAuthSettings } from "../schema/client"
-import { splitArgs } from "../cli/schema"
 import {
   addFieldCommand,
   addIndexCommand,
@@ -178,26 +177,5 @@ describe("resolveAuthSettings", () => {
         "POCKETBASE_ADMIN_EMAIL is missing",
       )
     })
-  })
-})
-
-describe("splitArgs", () => {
-  test("parses single-dash short flags with a value", () => {
-    const { positionals, flags } = splitArgs(["-c", "./my-config.ts"])
-    expect(positionals).toEqual([])
-    expect(flags.get("c")).toBe("./my-config.ts")
-  })
-
-  test("parses long flags and positionals together", () => {
-    const { positionals, flags } = splitArgs(["posts", "--out", "snap.json", "--delete-missing"])
-    expect(positionals).toEqual(["posts"])
-    expect(flags.get("out")).toBe("snap.json")
-    expect(flags.get("delete-missing")).toBe(true)
-  })
-
-  test("treats a following flag as a boolean, not a value", () => {
-    const { flags } = splitArgs(["--delete-missing", "-c", "cfg.ts"])
-    expect(flags.get("delete-missing")).toBe(true)
-    expect(flags.get("c")).toBe("cfg.ts")
   })
 })


### PR DESCRIPTION
Follow-up to #60 — migrates the CLI from the hand-rolled arg parser to [citty](https://github.com/unjs/citty).

## What

- `cli/index.ts` + `cli/schema.ts` rewritten as `defineCommand`/`runMain` with `generate` + `schema` (8 nested subcommands).
- Declarative, typed args/positionals → **auto-generated `--help`/usage** for every command and consistent flag parsing (short flags like `-c` now work everywhere, not just on `generate`).
- `cli/action.ts`: small wrapper preserving the previous clean one-line error output (citty's default dumps a full stack, and its `CLIError` isn't exported).
- Drops the `splitArgs` unit tests (parsing is citty's job now); command-merge and auth-resolution tests remain.
- Adds `citty` as pbkit's first runtime dependency.

`pbkit generate` behavior is unchanged.

## Verification

- `tsc --noEmit` clean
- `bun test` — 139 pass / 0 fail
- Build OK
- Manually verified: auto-help for `pbkit` / `pbkit schema` / each subcommand; clean one-line errors for no-creds / partial-creds / no-config; unknown-command shows usage; `generate` paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)