### PR TITLE
feat(sdk-generator): make OAuth2 redirectUrl optional (#63)

### DIFF
--- a/.changeset/oauth2-redirect-optional.md
+++ b/.changeset/oauth2-redirect-optional.md
@@ -1,0 +1,5 @@
+---
+"@karnak19/pbkit": patch
+---
+
+Make `redirectUrl` optional in generated `auth*WithOAuth2` functions, matching PocketBase v0.39.4 which dropped the required `redirectURL` validator from `authWithOAuth2Code()`.

--- a/packages/pbkit/src/sdk-generator/generate.ts
+++ b/packages/pbkit/src/sdk-generator/generate.ts
@@ -164,7 +164,7 @@ function authFunctions(col: CollectionSchema): string[] {
   lines.push("}");
   lines.push("");
   lines.push(
-    `export async function auth${s}WithOAuth2(provider: string, code: string, codeVerifier: string, redirectUrl: string, opts?: { client?: PbClient }): Promise<${p}Record> {`,
+    `export async function auth${s}WithOAuth2(provider: string, code: string, codeVerifier: string, redirectUrl = "", opts?: { client?: PbClient }): Promise<${p}Record> {`,
   );
   lines.push("  const pb = opts?.client ?? client");
   lines.push(

--- a/packages/pbkit/src/test/__snapshots__/sdk-generator.test.ts.snap
+++ b/packages/pbkit/src/test/__snapshots__/sdk-generator.test.ts.snap
@@ -62,7 +62,7 @@ export async function authUserWithPassword(usernameOrEmail: string, password: st
   return result.record as unknown as UsersRecord
 }
 
-export async function authUserWithOAuth2(provider: string, code: string, codeVerifier: string, redirectUrl: string, opts?: { client?: PbClient }): Promise<UsersRecord> {
+export async function authUserWithOAuth2(provider: string, code: string, codeVerifier: string, redirectUrl = "", opts?: { client?: PbClient }): Promise<UsersRecord> {
   const pb = opts?.client ?? client
   const result = await pb.collection("users").authWithOAuth2Code(provider, code, codeVerifier, redirectUrl)
   return result.record as unknown as UsersRecord


### PR DESCRIPTION
Makes the generated `auth*WithOAuth2` functions accept an optional `redirectUrl` (defaulting to `""`), matching PocketBase v0.39.4 which dropped the required `redirectURL` validator from `authWithOAuth2Code()`. The param stays typed as a string since PB's SDK requires it. Updated the generator, regenerated the snapshot, and added a patch changeset. Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)